### PR TITLE
CI strengthening: release validation guardrails

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,15 +5,16 @@
 ## Checks
 
 - [ ] `./scripts/ci-validate.sh`
+- [ ] `./scripts/test-release-scripts.sh`
 - [ ] `swift build`
 - [ ] `swift test`
 - [ ] `git diff --check`
 - [ ] UI/app changes smoke-tested with `./scripts/bundle.sh debug`
-- [ ] Script/workflow changes covered by `./scripts/ci-validate.sh`
+- [ ] Script/workflow changes covered by `./scripts/ci-validate.sh` and relevant fixture/validator scripts
 
 ## Release Notes And Docs
 
-- [ ] Added or updated a release/change note, or this PR does not need one
+- [ ] Added or updated a release/change note, or applied the `no-release-note` label for docs/meta-only work
 - [ ] Updated `docs/wiki` for user-facing behavior or workflow changes, or this PR does not need docs
 - [ ] Synced `Sources/Contained/Resources/CHANGELOG.md` when `CHANGELOG.md` changed (`./scripts/sync-changelog-resource.sh --check` passes)
 
@@ -22,3 +23,4 @@
 - [ ] Did not compute build numbers outside `scripts/version-info.sh`
 - [ ] Did not remove Nightly's ability to receive promoted Beta/Stable appcast items
 - [ ] Did not introduce generated-file commits that can trigger release loops
+- [ ] Bundle/appcast changes were validated with `scripts/validate-bundle.sh` / `scripts/validate-appcast.sh`

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -59,8 +59,10 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/ci-validate.sh
+          ./scripts/test-release-scripts.sh
           swift build -c release
           swift test
+          ./scripts/check-generated-clean.sh
 
       - name: Bundle (ad-hoc signed) + DMG
         if: steps.guard.outputs.build == 'true'
@@ -78,6 +80,8 @@ jobs:
             echo "VERSION=${VERSION}"
           } >> "$GITHUB_ENV"
           CHANNEL=beta BUILD="${BUILD}" VERSION="${VERSION}" ./scripts/bundle.sh release
+          VERSION="${VERSION}" BUILD="${BUILD}" ./scripts/validate-bundle.sh Contained.app
+          ./scripts/check-generated-clean.sh
           mkdir -p updates
           brew install create-dmg
           ./scripts/make-dmg.sh beta Contained.app "updates/Contained-${VERSION}.dmg"
@@ -116,6 +120,7 @@ jobs:
           ED_KEY_FILE="$KEYFILE" \
             DOWNLOAD_PREFIX="https://github.com/tdeverx/contained-app/releases/download/v${VERSION}/" \
             ./scripts/appcast.sh "$BIN" updates
+          CHANNEL=beta ./scripts/validate-appcast.sh appcast.xml
           rm -f "$KEYFILE"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -136,6 +141,7 @@ jobs:
           ./scripts/promote-appcast-to-nightly.sh "$PROMOTED_APPCAST" "$NIGHTLY_WORKTREE/appcast.xml"
           (
             cd "$NIGHTLY_WORKTREE"
+            CHANNEL=nightly "$GITHUB_WORKSPACE/scripts/validate-appcast.sh" appcast.xml
             git config user.name  "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add appcast.xml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,8 +50,10 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/ci-validate.sh
+          ./scripts/test-release-scripts.sh
           swift build -c release
           swift test
+          ./scripts/check-generated-clean.sh
 
       - name: Bundle (ad-hoc signed) + DMG
         run: |
@@ -67,6 +69,8 @@ jobs:
             echo "VERSION=${VERSION}"
           } >> "$GITHUB_ENV"
           CHANNEL=nightly BUILD="${BUILD}" VERSION="${VERSION}" ./scripts/bundle.sh release
+          VERSION="${VERSION}" BUILD="${BUILD}" ./scripts/validate-bundle.sh Contained.app
+          ./scripts/check-generated-clean.sh
           mkdir -p updates
           brew install create-dmg
           ./scripts/make-dmg.sh nightly Contained.app "updates/Contained-${VERSION}.dmg"
@@ -99,6 +103,7 @@ jobs:
             DOWNLOAD_PREFIX="https://github.com/tdeverx/contained-app/releases/download/nightly-latest/" \
             ./scripts/appcast.sh "$BIN" updates
           [ -s "$PREVIOUS_APPCAST" ] && ./scripts/promote-appcast-to-nightly.sh --non-nightly-only "$PREVIOUS_APPCAST" appcast.xml
+          CHANNEL=nightly ./scripts/validate-appcast.sh appcast.xml
           rm -f "$KEYFILE"
           rm -f "$PREVIOUS_APPCAST"
           git config user.name  "github-actions[bot]"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,10 +32,29 @@ jobs:
         run: swift --version && xcodebuild -version
 
       - name: Repository validation
-        run: ./scripts/ci-validate.sh
+        env:
+          NO_RELEASE_NOTE: ${{ contains(github.event.pull_request.labels.*.name, 'no-release-note') && '1' || '' }}
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          ./scripts/ci-validate.sh --base-ref "origin/${{ github.base_ref }}" --require-release-note
+
+      - name: Release script fixtures
+        run: ./scripts/test-release-scripts.sh
 
       - name: Build & test
         run: |
           set -euo pipefail
           swift build -c release
           swift test
+          ./scripts/check-generated-clean.sh
+
+      - name: Bundle smoke validation
+        run: |
+          set -euo pipefail
+          BUILD=$(CHANNEL=nightly ./scripts/version-info.sh build)
+          SHA=$(CHANNEL=nightly ./scripts/version-info.sh sha)
+          VERSION=$(CHANNEL=nightly BUILD="${BUILD}" SHA="${SHA}" ./scripts/version-info.sh version)
+          CHANNEL=nightly BUILD="${BUILD}" VERSION="${VERSION}" ./scripts/bundle.sh release
+          VERSION="${VERSION}" BUILD="${BUILD}" ./scripts/validate-bundle.sh Contained.app
+          ./scripts/check-generated-clean.sh

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -60,8 +60,10 @@ jobs:
         run: |
           set -euo pipefail
           ./scripts/ci-validate.sh
+          ./scripts/test-release-scripts.sh
           swift build -c release
           swift test
+          ./scripts/check-generated-clean.sh
 
       - name: Bundle (ad-hoc signed) + DMG
         if: steps.guard.outputs.build == 'true'
@@ -79,6 +81,8 @@ jobs:
             echo "VERSION=${VERSION}"
           } >> "$GITHUB_ENV"
           CHANNEL=stable BUILD="${BUILD}" VERSION="${VERSION}" ./scripts/bundle.sh release
+          VERSION="${VERSION}" BUILD="${BUILD}" ./scripts/validate-bundle.sh Contained.app
+          ./scripts/check-generated-clean.sh
           mkdir -p updates
           brew install create-dmg
           ./scripts/make-dmg.sh stable Contained.app "updates/Contained-${VERSION}.dmg"
@@ -117,6 +121,7 @@ jobs:
           ED_KEY_FILE="$KEYFILE" \
             DOWNLOAD_PREFIX="https://github.com/tdeverx/contained-app/releases/download/v${VERSION}/" \
             ./scripts/appcast.sh "$BIN" updates
+          CHANNEL=stable ./scripts/validate-appcast.sh appcast.xml
           rm -f "$KEYFILE"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -137,6 +142,7 @@ jobs:
           ./scripts/promote-appcast-to-nightly.sh "$PROMOTED_APPCAST" "$NIGHTLY_WORKTREE/appcast.xml"
           (
             cd "$NIGHTLY_WORKTREE"
+            CHANNEL=nightly "$GITHUB_WORKSPACE/scripts/validate-appcast.sh" appcast.xml
             git config user.name  "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add appcast.xml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ This file is the working contract for coding agents in this repository. Follow i
 - Stable and beta own their branch appcasts; nightly is a superset feed that also receives promoted beta/stable appcast items.
 - Appcast-only bot commits must not trigger release loops. Keep `appcast.xml` path-ignored in workflows and use `[skip ci]` for appcast bot commits.
 - PR/release workflows run `scripts/ci-validate.sh`; keep that script fast and focused on repository invariants before expensive Swift builds.
+- PR CI enforces release-note coverage for material changes. Add a changelog/change fragment, or use the `no-release-note` label only for docs/meta-only work.
+- Release workflows validate built bundles and generated appcasts before publishing or committing feed changes.
 
 ## Release Notes
 
@@ -45,6 +47,7 @@ This file is the working contract for coding agents in this repository. Follow i
 - Do not write app personalization back as `contained.*` labels. Only `contained.restart` and `contained.stack` may round-trip through container labels.
 - Keep helper scripts in `scripts/` and prefer hyphenated file names for multi-word shell scripts.
 - Keep comments human and useful. Explain surprising intent, not obvious syntax.
+- Debug-only tools, menus, and diagnostics must be guarded with `#if CONTAINED_DEBUG_TOOLS`; SwiftPM defines it only for debug builds so release bundles exclude that code.
 - Avoid large file reshuffles unless they reduce real complexity or match existing ownership boundaries.
 
 ## Verification
@@ -61,7 +64,16 @@ For release scripts/workflows:
 
 ```sh
 ./scripts/ci-validate.sh
+./scripts/test-release-scripts.sh
 swift test --filter UpdaterControllerTests
+```
+
+For generated release artifacts:
+
+```sh
+VERSION="$VERSION" BUILD="$BUILD" ./scripts/validate-bundle.sh Contained.app
+CHANNEL=nightly ./scripts/validate-appcast.sh appcast.xml
+./scripts/check-generated-clean.sh
 ```
 
 For app/UI changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,9 @@
 - **CI validation guardrail**: Added `scripts/ci-validate.sh` for bundled changelog drift, shell
   syntax, workflow YAML syntax, and Stable/Beta/Nightly release-note ordering; PR and release
   workflows now fail on drift instead of rewriting tracked resources in CI.
+- **CI strengthening pass**: Added PR release-note enforcement, release-script fixture coverage,
+  generated-file drift checks, bundle validation, appcast validation, and the
+  `CONTAINED_DEBUG_TOOLS` debug-only compile flag so diagnostics can stay out of release bundles.
 - **Release workflow rerun safety**: Beta and Stable workflows now update existing GitHub releases
   on reruns, and local `scripts/release.sh` defaults to the Stable channel to avoid accidentally
   cutting a stable version with nightly assets.

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,10 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
             ],
             path: "Sources/Contained",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: [
+                .define("CONTAINED_DEBUG_TOOLS", .when(configuration: .debug)),
+            ]
         ),
         .testTarget(
             name: "ContainedCoreTests",

--- a/Sources/Contained/Resources/CHANGELOG.md
+++ b/Sources/Contained/Resources/CHANGELOG.md
@@ -148,6 +148,9 @@
 - **CI validation guardrail**: Added `scripts/ci-validate.sh` for bundled changelog drift, shell
   syntax, workflow YAML syntax, and Stable/Beta/Nightly release-note ordering; PR and release
   workflows now fail on drift instead of rewriting tracked resources in CI.
+- **CI strengthening pass**: Added PR release-note enforcement, release-script fixture coverage,
+  generated-file drift checks, bundle validation, appcast validation, and the
+  `CONTAINED_DEBUG_TOOLS` debug-only compile flag so diagnostics can stay out of release bundles.
 - **Release workflow rerun safety**: Beta and Stable workflows now update existing GitHub releases
   on reruns, and local `scripts/release.sh` defaults to the Stable channel to avoid accidentally
   cutting a stable version with nightly assets.

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -26,16 +26,19 @@ appcast.xml              Sparkle feed at the root of each release branch
 - **No `contained.*` personalization labels.** Card styles and healthchecks live in local stores. Only `contained.restart` and `contained.stack` are written (they must round-trip through the container).
 - **Never put secrets or personal data in test fixtures.** Fixtures are captured CLI output — scrub tokens, domains, and paths before committing. (`.gitignore` blocks signing material; push protection is on.)
 - **Match the surrounding style** — comment density, naming, Liquid Glass idioms. Prefer shared primitives such as `PanelHeader`, `PanelSection`, `MorphPanelScaffold`, `ResourceGlassCard`, `CommandPreviewBar`, and `Tokens`.
+- **Gate debug-only tools at compile time.** Use `#if CONTAINED_DEBUG_TOOLS` for debug menus, diagnostics, fixtures, or local-only inspection surfaces. SwiftPM defines that flag only for debug builds, so release bundles exclude the code instead of merely hiding it at runtime.
 - **Keep the sidebar fallback working.** Toolbar-first UI and toolbar panel navigation are experimental gates, not replacements for the classic shell.
 - **Sync docs with behavior.** If behavior, settings, routes, or user-facing wording changes, update the matching page under `docs/wiki` and keep README links current.
 - **Preserve update build numbers.** `scripts/version-info.sh` is the single build-number source of truth; beta/stable workflows must pass the retained `BUILD` into `scripts/bundle.sh` and merge promoted appcast items into the nightly feed.
 - **Write release notes at the right level.** Put version-wide notes under the base version section, such as `## [1.0.0]`. Put channel/build changes under `Unreleased`, `## [nightly]`, `## [beta]`, or split them into `CHANGES_DIR` fragments. Prefer one fragment per PR/user-facing change under `changes/unreleased/` over one file per commit. `scripts/collect-changes.sh` can compile those fragments for a directory or git range. Stable ships full notes only; Beta/Nightly ship channel changes plus full notes.
-- **Let CI check invariants, not fix them.** `scripts/ci-validate.sh` checks bundled changelog sync, shell syntax, workflow YAML syntax, and Stable/Beta/Nightly release-note ordering. If `CHANGELOG.md` changes, run `./scripts/sync-changelog-resource.sh` locally and commit the bundled resource; CI uses `--check` so drift fails loudly.
+- **Let CI check invariants, not fix them.** `scripts/ci-validate.sh` checks bundled changelog sync, shell syntax, workflow YAML syntax, Stable/Beta/Nightly release-note ordering, and PR release-note coverage when given a base ref. If `CHANGELOG.md` changes, run `./scripts/sync-changelog-resource.sh` locally and commit the bundled resource; CI uses `--check` so drift fails loudly.
+- **Use `no-release-note` narrowly.** PR CI accepts the label only through `NO_RELEASE_NOTE=1`; reserve it for docs/meta-only work that does not change shipped behavior, scripts, workflows, tests, or source.
 
 ## Before a PR
 
 ```sh
 ./scripts/ci-validate.sh                       # release/workflow invariants
+./scripts/test-release-scripts.sh              # release script fixtures
 swift build && swift test                     # must be green
 git diff --check                              # no whitespace damage
 ./scripts/bundle.sh debug && open Contained.app # smoke-test the screens you touched

--- a/docs/wiki/Release.md
+++ b/docs/wiki/Release.md
@@ -52,7 +52,17 @@ When using a single `CHANGELOG.md`, keep `Unreleased` above released version sec
 
 Generated release-note files should be written under `updates/`, `.release/`, or `.release-notes/`. Do not commit generated notes from release workflows. The workflows only commit `appcast.xml`, and appcast-only commits are path-ignored and marked `[skip ci]` so they do not start another release build.
 
-Run `./scripts/ci-validate.sh` before opening release/workflow PRs. It checks bundled changelog sync, shell syntax, workflow YAML syntax, and the expected Stable/Beta/Nightly release-note shape. CI runs the same script before Swift builds.
+Run `./scripts/ci-validate.sh` before opening release/workflow PRs. It checks bundled changelog sync, shell syntax, workflow YAML syntax, and the expected Stable/Beta/Nightly release-note shape. PR CI also passes a base ref so material source/script/workflow changes must include a release note or change fragment unless the PR carries the `no-release-note` label.
+
+Release helper behavior is covered by `./scripts/test-release-scripts.sh`. CI also runs:
+
+```sh
+./scripts/check-generated-clean.sh
+VERSION="$VERSION" BUILD="$BUILD" ./scripts/validate-bundle.sh Contained.app
+CHANNEL="$CHANNEL" ./scripts/validate-appcast.sh appcast.xml
+```
+
+`check-generated-clean.sh` catches tracked files rewritten by build/generation steps. `validate-bundle.sh` checks the bundle executable, Info.plist version/build values, bundled changelog, Sparkle.framework, and code signature. `validate-appcast.sh` checks XML structure, numeric Sparkle build numbers, short versions, enclosure URLs, release notes, and channel shape; the nightly channel intentionally allows Stable/Beta/Nightly items because it is the superset feed.
 
 ## One-time setup
 
@@ -79,6 +89,8 @@ Then:
 `.github/workflows/nightly.yml` builds the latest green `nightly` on every push (newest commit wins via `concurrency: cancel-in-progress`), ad-hoc signs, refreshes the rolling **nightly** pre-release with the new DMG, regenerates the nightly appcast item, preserves promoted beta/stable items already in the feed, and commits root `appcast.xml` to the `nightly` branch. It skips appcast signing when `SPARKLE_ED_PRIVATE_KEY` is absent.
 
 `.github/workflows/beta.yml` and `.github/workflows/stable.yml` build promoted branches, retain the build number for the matching nightly commit when available, write their own branch appcast, and merge the promoted appcast item into the nightly feed. They upsert GitHub release assets on reruns so a retry refreshes the same tag instead of failing on an existing release. All workflows ask `scripts/version-info.sh` for the build number.
+
+After appcast generation, workflows validate the branch feed before committing it. Beta and Stable workflows validate the promoted nightly feed inside the temporary nightly worktree before pushing the appcast-only `[skip ci]` commit.
 
 ## Notes
 

--- a/docs/wiki/Updates.md
+++ b/docs/wiki/Updates.md
@@ -29,6 +29,12 @@ Release workflows only commit root `appcast.xml` back to channel branches.
 Those appcast-only commits are path-ignored and marked `[skip ci]` to avoid
 release loops.
 
+CI validates generated appcasts before those commits. The validator requires a
+numeric Sparkle build number, a short version, an enclosure URL, and embedded or
+linked release notes. Stable feeds reject Beta/Nightly short versions, Beta feeds
+require Beta short versions, and Nightly feeds allow all three channels because
+Nightly users should receive promoted builds without switching channels.
+
 Fresh installs default to Nightly during pre-1.0 development.
 
 ## Release notes
@@ -51,6 +57,8 @@ Generated notes follow the channel:
 `scripts/ci-validate.sh` checks that ordering before CI builds, and
 `scripts/sync-changelog-resource.sh --check` fails when the bundled in-app
 changelog resource has drifted from the root `CHANGELOG.md`.
+PR CI also requires material source/script/workflow changes to include a release
+note or change fragment unless the PR is explicitly labeled `no-release-note`.
 
 ## Image updates
 

--- a/scripts/check-generated-clean.sh
+++ b/scripts/check-generated-clean.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Ensure build/generation steps did not leave tracked files dirty.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+git update-index -q --refresh
+
+if ! git diff --quiet --exit-code || ! git diff --cached --quiet --exit-code; then
+  echo "✗ Tracked files changed unexpectedly:" >&2
+  git status --short >&2
+  exit 1
+fi
+
+echo "✓ No tracked generated-file drift."

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -4,6 +4,33 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+base_ref=""
+head_ref="HEAD"
+require_release_note=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base-ref)
+      base_ref="${2:-}"
+      [ -n "$base_ref" ] || { echo "✗ --base-ref requires a value" >&2; exit 1; }
+      shift 2
+      ;;
+    --head-ref)
+      head_ref="${2:-}"
+      [ -n "$head_ref" ] || { echo "✗ --head-ref requires a value" >&2; exit 1; }
+      shift 2
+      ;;
+    --require-release-note)
+      require_release_note=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--base-ref <ref>] [--head-ref <ref>] [--require-release-note]" >&2
+      exit 1
+      ;;
+  esac
+done
+
 fail() {
   echo "✗ $*" >&2
   exit 1
@@ -50,5 +77,10 @@ nightly_full_line="$(printf '%s\n' "$nightly_notes" | first_line_matching '^## F
 [ -n "$nightly_changes_line" ] || fail "nightly release notes are missing Changes Since Last Nightly"
 [ -n "$nightly_full_line" ] || fail "nightly release notes are missing Full Release Notes"
 [ "$nightly_changes_line" -lt "$nightly_full_line" ] || fail "nightly changes must appear before full release notes"
+
+if $require_release_note; then
+  echo "▸ Checking PR release-note coverage…"
+  BASE_REF="$base_ref" HEAD_REF="$head_ref" ./scripts/require-release-note.sh
+fi
 
 echo "✓ CI validation passed."

--- a/scripts/require-release-note.sh
+++ b/scripts/require-release-note.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Fail material PRs that forget a committed release note or change fragment.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail() {
+  echo "✗ $*" >&2
+  exit 1
+}
+
+base_ref="${BASE_REF:-${1:-}}"
+head_ref="${HEAD_REF:-${2:-HEAD}}"
+
+if [ "${NO_RELEASE_NOTE:-}" = "1" ]; then
+  echo "✓ Release-note requirement skipped by NO_RELEASE_NOTE=1."
+  exit 0
+fi
+
+[ -n "$base_ref" ] || fail "BASE_REF is required for release-note enforcement"
+git rev-parse --verify "$base_ref" >/dev/null 2>&1 || fail "Base ref '$base_ref' was not found"
+git rev-parse --verify "$head_ref" >/dev/null 2>&1 || fail "Head ref '$head_ref' was not found"
+
+changed_files="$(git diff --name-only --diff-filter=ACMR "$base_ref...$head_ref")"
+if [ -z "$changed_files" ]; then
+  echo "✓ No changed files to inspect for release notes."
+  exit 0
+fi
+
+has_note=false
+has_material_change=false
+
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+
+  case "$file" in
+    CHANGELOG.md|Sources/Contained/Resources/CHANGELOG.md|RELEASE_NOTES.md|CHANGES.md|changes/*.md|changes/*/*.md)
+      has_note=true
+      ;;
+  esac
+
+  case "$file" in
+    Package.swift|Package.resolved|VERSION|Sources/**|Tests/**|Resources/**|scripts/**|.github/workflows/**)
+      has_material_change=true
+      ;;
+  esac
+done <<< "$changed_files"
+
+if $has_material_change && ! $has_note; then
+  echo "✗ Material changes need a release note or change fragment." >&2
+  echo >&2
+  echo "Changed files:" >&2
+  while IFS= read -r file; do
+    [ -n "$file" ] && printf '  %s\n' "$file" >&2
+  done <<< "$changed_files"
+  echo >&2
+  echo "Add one of:" >&2
+  echo "  - CHANGELOG.md plus synced Sources/Contained/Resources/CHANGELOG.md" >&2
+  echo "  - changes/unreleased/YYYYMMDD-short-slug.md" >&2
+  echo "  - RELEASE_NOTES.md / CHANGES.md when the release train uses split files" >&2
+  echo >&2
+  echo "For docs/meta-only work, apply the 'no-release-note' PR label so CI sets NO_RELEASE_NOTE=1." >&2
+  exit 1
+fi
+
+echo "✓ Release-note requirement passed."

--- a/scripts/test-release-scripts.sh
+++ b/scripts/test-release-scripts.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Fixture coverage for release/version/change/appcast helper scripts.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail() {
+  echo "✗ $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  grep -Fq -- "$needle" <<< "$haystack" || fail "$label did not contain '$needle'"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" <<< "$haystack"; then
+    fail "$label unexpectedly contained '$needle'"
+  fi
+}
+
+mkdir -p .release
+tmp="$(mktemp -d .release/test-release-scripts.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "▸ Checking version-info validation..."
+if BUILD=abc ./scripts/version-info.sh build >/dev/null 2>&1; then
+  fail "version-info accepted a non-numeric BUILD"
+fi
+
+env_output="$(CHANNEL=beta BUILD=123 SHA=abcdef0 BASE_VERSION=9.8.7 ./scripts/version-info.sh env)"
+assert_contains "$env_output" "BASE_VERSION=9.8.7" "version-info env"
+assert_contains "$env_output" "BUILD=123" "version-info env"
+assert_contains "$env_output" "SHA=abcdef0" "version-info env"
+assert_contains "$env_output" "VERSION=9.8.7-beta.123+abcdef0" "version-info env"
+
+echo "▸ Checking release-note composition..."
+fixture_changelog="$tmp/CHANGELOG.md"
+cat > "$fixture_changelog" <<'MARKDOWN'
+# Changelog
+
+## [Unreleased] - Current Build
+
+### Fixed
+
+- Build-specific fix.
+
+## [9.8.7] - Version Notes
+
+### Added
+
+- Version-wide feature.
+MARKDOWN
+
+stable_notes="$(CHANGELOG="$fixture_changelog" VERSION_VALUE=9.8.7 CHANNEL=stable ./scripts/release-body.sh)"
+assert_contains "$stable_notes" "## Full Release Notes" "stable notes"
+assert_contains "$stable_notes" "Version-wide feature." "stable notes"
+assert_not_contains "$stable_notes" "Changes Since Last" "stable notes"
+
+beta_notes="$(CHANGELOG="$fixture_changelog" VERSION_VALUE=9.8.7-beta.123+abcdef0 CHANNEL=beta ./scripts/release-body.sh)"
+assert_contains "$beta_notes" "## Changes Since Last Beta" "beta notes"
+assert_contains "$beta_notes" "Build-specific fix." "beta notes"
+assert_contains "$beta_notes" "## Full Release Notes" "beta notes"
+assert_contains "$beta_notes" "Version-wide feature." "beta notes"
+
+nightly_notes="$(CHANGELOG="$fixture_changelog" VERSION_VALUE=9.8.7-nightly.123+abcdef0 CHANNEL=nightly ./scripts/release-body.sh)"
+assert_contains "$nightly_notes" "## Changes Since Last Nightly" "nightly notes"
+assert_contains "$nightly_notes" "Build-specific fix." "nightly notes"
+assert_contains "$nightly_notes" "## Full Release Notes" "nightly notes"
+
+echo "▸ Checking change-fragment collection..."
+mkdir -p "$tmp/changes"
+printf '%s\n' '- Second fragment.' > "$tmp/changes/20260701-b.md"
+printf '%s\n' '- First fragment.' > "$tmp/changes/20260701-a.md"
+fragment_output="$(./scripts/collect-changes.sh "$tmp/changes")"
+assert_contains "$fragment_output" "- First fragment." "fragment collection"
+assert_contains "$fragment_output" "- Second fragment." "fragment collection"
+
+echo "▸ Checking appcast promotion and validation..."
+promoted="$tmp/promoted.xml"
+beta_only="$tmp/beta.xml"
+stable_only="$tmp/stable.xml"
+nightly="$tmp/nightly.xml"
+cat > "$promoted" <<'XML'
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <title>Contained</title>
+    <item>
+      <title>9.8.7-beta.123+abcdef0</title>
+      <sparkle:version>123</sparkle:version>
+      <sparkle:shortVersionString>9.8.7-beta.123+abcdef0</sparkle:shortVersionString>
+      <description>Beta notes.</description>
+      <enclosure url="https://example.com/Contained.dmg" length="1" type="application/octet-stream"/>
+    </item>
+    <item>
+      <title>9.8.7-nightly.124+abcdef1</title>
+      <sparkle:version>124</sparkle:version>
+      <sparkle:shortVersionString>9.8.7-nightly.124+abcdef1</sparkle:shortVersionString>
+      <description>Nightly notes.</description>
+      <enclosure url="https://example.com/Contained-nightly.dmg" length="1" type="application/octet-stream"/>
+    </item>
+  </channel>
+</rss>
+XML
+cat > "$beta_only" <<'XML'
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <title>Contained</title>
+    <item>
+      <title>9.8.7-beta.123+abcdef0</title>
+      <sparkle:version>123</sparkle:version>
+      <sparkle:shortVersionString>9.8.7-beta.123+abcdef0</sparkle:shortVersionString>
+      <description>Beta notes.</description>
+      <enclosure url="https://example.com/Contained.dmg" length="1" type="application/octet-stream"/>
+    </item>
+  </channel>
+</rss>
+XML
+cat > "$stable_only" <<'XML'
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <title>Contained</title>
+    <item>
+      <title>9.8.7</title>
+      <sparkle:version>123</sparkle:version>
+      <sparkle:shortVersionString>9.8.7</sparkle:shortVersionString>
+      <description>Stable notes.</description>
+      <enclosure url="https://example.com/Contained.dmg" length="1" type="application/octet-stream"/>
+    </item>
+  </channel>
+</rss>
+XML
+
+CHANNEL=beta ./scripts/validate-appcast.sh "$beta_only" >/dev/null
+CHANNEL=stable ./scripts/validate-appcast.sh "$stable_only" >/dev/null
+./scripts/promote-appcast-to-nightly.sh --non-nightly-only "$promoted" "$nightly" >/dev/null
+promoted_output="$(cat "$nightly")"
+assert_contains "$promoted_output" "9.8.7-beta.123+abcdef0" "promoted appcast"
+assert_not_contains "$promoted_output" "9.8.7-nightly.124+abcdef1" "promoted appcast"
+CHANNEL=nightly ./scripts/validate-appcast.sh "$nightly" >/dev/null
+
+echo "✓ Release script fixture tests passed."

--- a/scripts/validate-appcast.sh
+++ b/scripts/validate-appcast.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Validate Sparkle appcast structure and channel/build invariants.
+set -euo pipefail
+
+appcast="${1:-appcast.xml}"
+channel="${CHANNEL:-nightly}"
+
+[ -f "$appcast" ] || { echo "✗ Appcast '$appcast' was not found" >&2; exit 1; }
+
+APPCAST="$appcast" CHANNEL_VALUE="$channel" ruby <<'RUBY'
+require "rexml/document"
+require "rexml/xpath"
+
+path = ENV.fetch("APPCAST")
+channel = ENV.fetch("CHANNEL_VALUE")
+allow_missing_notes = ENV["ALLOW_MISSING_RELEASE_NOTES"] == "1"
+namespaces = { "sparkle" => "http://www.andymatuschak.org/xml-namespaces/sparkle" }
+
+def fail!(message)
+  warn "✗ #{message}"
+  exit 1
+end
+
+unless %w[stable beta nightly].include?(channel)
+  fail!("Unknown CHANNEL '#{channel}' (expected stable, beta, or nightly)")
+end
+
+doc = REXML::Document.new(File.read(path))
+items = REXML::XPath.match(doc, "//item")
+fail!("Appcast has no <item> entries") if items.empty?
+
+items.each_with_index do |item, index|
+  label = "item #{index + 1}"
+  version = REXML::XPath.first(item, "sparkle:version", namespaces)&.text.to_s.strip
+  short_version = REXML::XPath.first(item, "sparkle:shortVersionString", namespaces)&.text.to_s.strip
+  enclosure = REXML::XPath.first(item, "enclosure")
+  enclosure_url = enclosure&.attributes&.[]("url").to_s.strip
+  description = REXML::XPath.first(item, "description")&.text.to_s.strip
+  release_notes_link = REXML::XPath.first(item, "sparkle:releaseNotesLink", namespaces)&.text.to_s.strip
+
+  fail!("#{label} is missing sparkle:version") if version.empty?
+  fail!("#{label} sparkle:version must be numeric, got '#{version}'") unless version.match?(/\A[1-9][0-9]*\z/)
+  fail!("#{label} is missing sparkle:shortVersionString") if short_version.empty?
+  fail!("#{label} is missing enclosure URL") if enclosure_url.empty?
+
+  unless allow_missing_notes || !description.empty? || !release_notes_link.empty?
+    fail!("#{label} is missing embedded or linked release notes")
+  end
+
+  case channel
+  when "stable"
+    if short_version.match?(/-(beta|nightly)\./)
+      fail!("#{label} is not a stable short version: #{short_version}")
+    end
+  when "beta"
+    unless short_version.include?("-beta.")
+      fail!("#{label} is not a beta short version: #{short_version}")
+    end
+  when "nightly"
+    # The nightly appcast is intentionally a superset of nightly, beta, and stable items.
+  end
+end
+
+puts "✓ Appcast validation passed for #{path} (#{channel}, #{items.length} item#{items.length == 1 ? "" : "s"})."
+RUBY

--- a/scripts/validate-bundle.sh
+++ b/scripts/validate-bundle.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Smoke-check a built Contained.app before packaging or publishing.
+set -euo pipefail
+
+app="${1:-Contained.app}"
+plist="$app/Contents/Info.plist"
+binary="$app/Contents/MacOS/Contained"
+resource_changelog="$app/Contents/Resources/Contained_Contained.bundle/CHANGELOG.md"
+sparkle_framework="$app/Contents/Frameworks/Sparkle.framework"
+
+fail() {
+  echo "✗ $*" >&2
+  exit 1
+}
+
+[ -d "$app" ] || fail "App bundle '$app' was not found"
+[ -f "$plist" ] || fail "Info.plist is missing"
+[ -x "$binary" ] || fail "Executable '$binary' is missing or not executable"
+[ -f "$resource_changelog" ] || fail "Bundled CHANGELOG.md resource is missing"
+[ -d "$sparkle_framework" ] || fail "Sparkle.framework is missing from the bundle"
+
+plist_value() {
+  /usr/libexec/PlistBuddy -c "Print :$1" "$plist"
+}
+
+short_version="$(plist_value CFBundleShortVersionString)"
+build_number="$(plist_value CFBundleVersion)"
+
+if [ -n "${VERSION:-}" ] && [ "$short_version" != "$VERSION" ]; then
+  fail "CFBundleShortVersionString '$short_version' does not match VERSION '$VERSION'"
+fi
+
+case "$build_number" in
+  ''|*[!0-9]*)
+    fail "CFBundleVersion must be a numeric build number, got '$build_number'"
+    ;;
+esac
+
+if [ -n "${BUILD:-}" ] && [ "$build_number" != "$BUILD" ]; then
+  fail "CFBundleVersion '$build_number' does not match BUILD '$BUILD'"
+fi
+
+codesign --verify --deep --strict "$app" >/dev/null 2>&1 || fail "codesign verification failed for '$app'"
+
+echo "✓ Bundle validation passed for $app ($short_version build $build_number)."


### PR DESCRIPTION
## Summary
- add PR release-note enforcement, release script fixture tests, generated-file drift checks, bundle validation, and appcast validation
- define CONTAINED_DEBUG_TOOLS for debug-only app tooling so release builds can exclude diagnostics at compile time
- wire the new validators into PR, nightly, beta, and stable workflows and document the workflow for contributors/agents

## Local checks
- ./scripts/ci-validate.sh
- ./scripts/test-release-scripts.sh
- CHANNEL=nightly ./scripts/validate-appcast.sh appcast.xml
- swift build -c release
- swift test
- ./scripts/validate-bundle.sh Contained.app
- ./scripts/check-generated-clean.sh
- git diff --check