### PR TITLE
Add wiki sync automation

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,8 +42,10 @@ jobs:
           git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           ./scripts/ci-validate.sh --base-ref "origin/${{ github.base_ref }}" --require-release-note
 
-      - name: Release script fixtures
-        run: ./scripts/test-release-scripts.sh
+      - name: Script fixtures
+        run: |
+          ./scripts/test-release-scripts.sh
+          ./scripts/test-wiki-scripts.sh
 
       - name: Build & test
         run: |

--- a/.github/workflows/wiki-pr.yml
+++ b/.github/workflows/wiki-pr.yml
@@ -1,0 +1,105 @@
+name: Wiki PR
+
+on:
+  pull_request:
+    branches: [main, nightly, beta, stable]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+concurrency:
+  group: wiki-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  wiki-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base
+        run: git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Wiki check
+        id: wiki_check
+        continue-on-error: true
+        env:
+          WIKI_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'wiki-approved') && '1' || '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .release/wiki-pr
+          args=(
+            --base-ref "origin/${{ github.base_ref }}"
+            --head-ref HEAD
+            --summary-file .release/wiki-pr/summary.md
+            --require-approval
+          )
+          if [ "$WIKI_APPROVED" = "1" ]; then
+            args+=(--approved)
+          fi
+          ./scripts/wiki-check.sh "${args[@]}"
+
+      - name: Render preview
+        if: always()
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p .release/wiki-pr/base-src
+          ./scripts/wiki-render.sh --source docs/wiki --output .release/wiki-pr/rendered --channel nightly
+          git archive "origin/${{ github.base_ref }}" docs/wiki | tar -x -C .release/wiki-pr/base-src
+          ./scripts/wiki-render.sh --source .release/wiki-pr/base-src/docs/wiki --output .release/wiki-pr/rendered-base --channel nightly
+          diff -ru .release/wiki-pr/rendered-base .release/wiki-pr/rendered > .release/wiki-pr/wiki.diff || true
+
+      - name: Upload preview
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wiki-preview
+          path: .release/wiki-pr
+          if-no-files-found: ignore
+
+      - name: Comment summary
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          body_file=.release/wiki-pr/summary.md
+          if [ ! -f "$body_file" ]; then
+            mkdir -p .release/wiki-pr
+            {
+              echo "<!-- contained-wiki-pr -->"
+              echo "## Wiki Review"
+              echo
+              echo "Status: wiki summary was not generated."
+            } > "$body_file"
+          fi
+          {
+            echo
+            echo "Preview artifact: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } >> "$body_file"
+          comment_id="$(
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+              --jq '.[] | select(.body | contains("<!-- contained-wiki-pr -->")) | .id' \
+              | head -n 1
+          )"
+          if [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" \
+              -f body="$(cat "$body_file")" >/dev/null
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -f body="$(cat "$body_file")" >/dev/null
+          fi
+
+      - name: Enforce wiki gate
+        if: always()
+        run: |
+          if [ "${{ steps.wiki_check.outcome }}" != "success" ]; then
+            exit 1
+          fi

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,71 @@
+name: Wiki Sync
+
+on:
+  push:
+    branches: [nightly]
+    paths:
+      - 'docs/wiki/**'
+      - 'scripts/wiki-*.sh'
+      - 'scripts/wiki-tool.rb'
+      - '.github/workflows/wiki-sync.yml'
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Render channel
+        required: true
+        default: nightly
+        type: choice
+        options:
+          - nightly
+          - beta
+          - stable
+      force:
+        description: Create a wiki commit even when rendered output is unchanged
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: wiki-sync-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      WIKI_SYNC_TOKEN: ${{ secrets.WIKI_SYNC_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Render wiki
+        env:
+          WIKI_CHANNEL: ${{ inputs.channel || 'nightly' }}
+        run: ./scripts/wiki-render.sh --source docs/wiki --output .release/wiki-sync/rendered --channel "$WIKI_CHANNEL"
+
+      - name: Publish wiki
+        env:
+          FORCE_SYNC: ${{ inputs.force || false }}
+        run: |
+          set -euo pipefail
+          token="${WIKI_SYNC_TOKEN:-$GH_TOKEN}"
+          wiki_dir=.release/wiki-sync/wiki
+          git clone "https://x-access-token:${token}@github.com/${GITHUB_REPOSITORY}.wiki.git" "$wiki_dir"
+          rsync -a --delete --exclude='.git/' --exclude='_Footer.md' .release/wiki-sync/rendered/ "$wiki_dir/"
+          cd "$wiki_dir"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet && [ "$FORCE_SYNC" != "true" ]; then
+            echo "wiki unchanged - nothing to publish."
+            exit 0
+          fi
+          if git diff --cached --quiet; then
+            git commit --allow-empty -m "docs: republish wiki"
+          else
+            git commit -m "docs: sync wiki"
+          fi
+          git push origin HEAD

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file is the working contract for coding agents in this repository. Follow i
 - This is a SwiftPM-first macOS 26 SwiftUI app.
 - `Sources/ContainedCore` is pure/testable logic. Keep SwiftUI, app state, Sparkle, and persistence out of it.
 - `Sources/Contained` is the app: SwiftUI screens, design system, navigation, stores, history, settings, and update support.
-- `docs/wiki` mirrors the GitHub wiki. User-facing behavior or workflow changes should update the matching page.
+- `docs/wiki` is the canonical GitHub wiki source. User-facing behavior or workflow changes should update the matching page; CI publishes the rendered wiki after merge.
 - Keep directory names intentional: SwiftPM-owned folders stay `Sources` and `Tests`, Swift source domain folders use PascalCase, and repo infrastructure uses lowercase names such as `docs` and `scripts`.
 
 ## Branches And Updates
@@ -20,6 +20,7 @@ This file is the working contract for coding agents in this repository. Follow i
 - CodeQL uses the checked-in advanced setup at `.github/workflows/codeql.yml`. Actions workflow analysis runs on PRs, pushes, and the weekly baseline; Swift analysis is scheduled/manual because Swift CodeQL currently takes too long to be a healthy per-PR gate. Keep appcast, docs, and release-note-only paths ignored there too.
 - PR/release workflows run `scripts/ci-validate.sh`; keep that script fast and focused on repository invariants before expensive Swift builds.
 - PR CI enforces release-note coverage for material changes. Add a changelog/change fragment, or use the `no-release-note` label only for docs/meta-only work.
+- Wiki-impacting PRs require the `wiki-approved` label. The PR wiki guard renders previews, posts a sticky review comment, and fails until that label is present.
 - Release workflows validate built bundles and generated appcasts before publishing or committing feed changes.
 
 ## Release Notes
@@ -67,6 +68,7 @@ For release scripts/workflows:
 ```sh
 ./scripts/ci-validate.sh
 ./scripts/test-release-scripts.sh
+./scripts/test-wiki-scripts.sh
 swift test --filter UpdaterControllerTests
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Maintainers use `scripts/release.sh` and `scripts/appcast.sh` for signing, notar
 
 ## Documentation
 
-The GitHub wiki is the source of truth for feature and implementation notes.
-The maintained wiki pages are mirrored in [`docs/wiki`](docs/wiki) so docs
-changes can be reviewed with code changes:
+[`docs/wiki`](docs/wiki) is the source of truth for feature and implementation
+notes. CI renders and publishes those pages to the GitHub wiki after merge, so
+docs changes can be reviewed with code changes:
 
 - Start: [Features](https://github.com/tdeverx/contained-app/wiki/Features), [Installation](https://github.com/tdeverx/contained-app/wiki/Installation), [Keyboard Shortcuts](https://github.com/tdeverx/contained-app/wiki/Keyboard-Shortcuts), [Troubleshooting](https://github.com/tdeverx/contained-app/wiki/Troubleshooting)
 - Workflows: [Creation Workflow](https://github.com/tdeverx/contained-app/wiki/Creation-Workflow), [Run / Edit Form](https://github.com/tdeverx/contained-app/wiki/Run-Edit-Form), [Compose Import](https://github.com/tdeverx/contained-app/wiki/Compose-Import), [Command Palette](https://github.com/tdeverx/contained-app/wiki/Command-Palette), [Updates](https://github.com/tdeverx/contained-app/wiki/Updates)

--- a/changes/unreleased/20260701-wiki-sync.md
+++ b/changes/unreleased/20260701-wiki-sync.md
@@ -1,0 +1,1 @@
+- Added wiki preview, approval, rendering, promotion, and publish automation so `docs/wiki/` can act as the canonical GitHub wiki source.

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -13,7 +13,7 @@ Sources/Contained/       the SwiftUI app
 Tests/ContainedCoreTests/  golden-argv + decode + decision tests
 Tests/ContainedAppTests/   RunSpec argv + compose mapping
 scripts/                 bundle.sh, release.sh, appcast.sh
-docs/wiki/               local mirror of the GitHub wiki pages
+docs/wiki/               canonical source rendered into the GitHub wiki
 appcast.xml              Sparkle feed at the root of each release branch
 ```
 
@@ -28,7 +28,8 @@ appcast.xml              Sparkle feed at the root of each release branch
 - **Match the surrounding style** — comment density, naming, Liquid Glass idioms. Prefer shared primitives such as `PanelHeader`, `PanelSection`, `MorphPanelScaffold`, `ResourceGlassCard`, `CommandPreviewBar`, and `Tokens`.
 - **Gate debug-only tools at compile time.** Use `#if CONTAINED_DEBUG_TOOLS` for debug menus, diagnostics, fixtures, or local-only inspection surfaces. SwiftPM defines that flag only for debug builds, so release bundles exclude the code instead of merely hiding it at runtime.
 - **Keep the sidebar fallback working.** Toolbar-first UI and toolbar panel navigation are experimental gates, not replacements for the classic shell.
-- **Sync docs with behavior.** If behavior, settings, routes, or user-facing wording changes, update the matching page under `docs/wiki` and keep README links current.
+- **Sync docs with behavior.** If behavior, settings, routes, or user-facing wording changes, update the matching page under `docs/wiki` and keep README links current. Wiki-impacting PRs need the `wiki-approved` label; the wiki PR guard renders a preview and blocks until that label is present.
+- **Publish the wiki from the repo.** The Wiki Sync workflow renders `docs/wiki` after merge and pushes the GitHub wiki. If the default GitHub token cannot push the wiki in a repository setting, configure a `WIKI_SYNC_TOKEN` secret with wiki write access.
 - **Preserve update build numbers.** `scripts/version-info.sh` is the single build-number source of truth; beta/stable workflows must pass the retained `BUILD` into `scripts/bundle.sh` and merge promoted appcast items into the nightly feed.
 - **Keep code scanning intentional.** `.github/workflows/codeql.yml` is the repository-owned CodeQL setup. GitHub Actions workflow analysis runs on PRs and pushes that touch source, scripts, workflows, package files, or tests, plus a weekly scheduled baseline. Swift analysis is scheduled/manual because Swift CodeQL currently takes too long to be a healthy per-PR gate. Appcast-only, docs-only, changelog-resource-only, and change-fragment-only commits are ignored so generated release feed commits do not burn macOS scan minutes.
 - **Write release notes at the right level.** Put version-wide notes under the base version section, such as `## [1.0.0]`. Put channel/build changes under `Unreleased`, `## [nightly]`, `## [beta]`, or split them into `CHANGES_DIR` fragments. Prefer one fragment per PR/user-facing change under `changes/unreleased/` over one file per commit. `scripts/collect-changes.sh` can compile those fragments for a directory or git range. When no explicit `CHANGES`/`CHANGES_DIR` source is provided, Beta/Nightly notes first try the previous matching appcast item plus the changelog/change-fragment git delta, then fall back to channel sections. Stable ships full notes only; Beta/Nightly ship channel changes plus full notes.

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -50,6 +50,10 @@ bash -n scripts/*.sh
 echo "▸ Checking workflow YAML syntax…"
 ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/*.yml
 
+echo "▸ Checking wiki docs…"
+ruby -c scripts/wiki-tool.rb >/dev/null
+./scripts/wiki-check.sh
+
 echo "▸ Checking release-note composition…"
 base="$(./scripts/version-info.sh base)"
 build="$(./scripts/version-info.sh build)"

--- a/scripts/test-wiki-scripts.sh
+++ b/scripts/test-wiki-scripts.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Fixture coverage for wiki marker validation, rendering, and promotion helpers.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail() {
+  echo "✗ $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  grep -Fq -- "$needle" <<< "$haystack" || fail "$label did not contain '$needle'"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq -- "$needle" <<< "$haystack"; then
+    fail "$label unexpectedly contained '$needle'"
+  fi
+}
+
+mkdir -p .release
+tmp="$(mktemp -d .release/wiki-tests.XXXXXX)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "▸ Checking wiki rendering..."
+source_dir="$tmp/source"
+mkdir -p "$source_dir"
+cat > "$source_dir/Home.md" <<'MARKDOWN'
+# Home
+
+See [[Details]].
+
+<!-- wiki:section id="update-channel-picker" -->
+## Update Channels
+
+Stable behavior.
+<!-- /wiki:section -->
+
+<!-- wiki:variant id="update-channel-picker" channel="nightly" since="1.1.0" -->
+### [Nightly] Update Channels
+
+Nightly behavior.
+<!-- /wiki:variant -->
+MARKDOWN
+cat > "$source_dir/Details.md" <<'MARKDOWN'
+# Details
+
+Everything else.
+MARKDOWN
+
+./scripts/wiki-check.sh --source "$source_dir"
+./scripts/wiki-render.sh --source "$source_dir" --output "$tmp/rendered-nightly" --channel nightly >/dev/null
+nightly_output="$(cat "$tmp/rendered-nightly/Home.md")"
+assert_contains "$nightly_output" "Deprecating in 1.1.0" "nightly render"
+assert_contains "$nightly_output" "### [Nightly] Update Channels" "nightly render"
+assert_not_contains "$nightly_output" "wiki:section" "nightly render"
+
+./scripts/wiki-render.sh --source "$source_dir" --output "$tmp/rendered-stable" --channel stable >/dev/null
+stable_output="$(cat "$tmp/rendered-stable/Home.md")"
+assert_not_contains "$stable_output" "[Nightly]" "stable render"
+assert_not_contains "$stable_output" "Deprecating" "stable render"
+
+echo "▸ Checking wiki validation failures..."
+bad_dir="$tmp/bad"
+mkdir -p "$bad_dir"
+cat > "$bad_dir/Home.md" <<'MARKDOWN'
+# Home
+
+See [[Missing]].
+
+<!-- wiki:section id="duplicate" -->
+## One
+<!-- /wiki:section -->
+
+<!-- wiki:section id="duplicate" -->
+## Two
+<!-- /wiki:section -->
+
+<!-- wiki:variant id="unknown" channel="nightly" since="1.1.0" -->
+### [Nightly] Unknown
+<!-- /wiki:variant -->
+MARKDOWN
+if ./scripts/wiki-check.sh --source "$bad_dir" >/dev/null 2>&1; then
+  fail "wiki-check accepted invalid markers"
+fi
+
+echo "▸ Checking wiki promotion..."
+promote_dir="$tmp/promote"
+mkdir -p "$promote_dir"
+cat > "$promote_dir/Page.md" <<'MARKDOWN'
+# Page
+
+<!-- wiki:section id="panel-flow" -->
+## Panel Flow
+
+Stable flow.
+<!-- /wiki:section -->
+
+<!-- wiki:variant id="panel-flow" channel="nightly" since="1.2.0" -->
+### [Nightly] Panel Flow
+
+Nightly flow.
+<!-- /wiki:variant -->
+MARKDOWN
+
+./scripts/wiki-promote.sh --source "$promote_dir" --from nightly --to beta >/dev/null
+promoted_beta="$(cat "$promote_dir/Page.md")"
+assert_contains "$promoted_beta" 'channel="beta"' "nightly to beta promotion"
+assert_contains "$promoted_beta" "### [Beta] Panel Flow" "nightly to beta promotion"
+assert_not_contains "$promoted_beta" "[Nightly]" "nightly to beta promotion"
+
+./scripts/wiki-promote.sh --source "$promote_dir" --from beta --to stable >/dev/null
+promoted_stable="$(cat "$promote_dir/Page.md")"
+assert_contains "$promoted_stable" "Nightly flow." "beta to stable promotion"
+assert_not_contains "$promoted_stable" "Stable flow." "beta to stable promotion"
+assert_not_contains "$promoted_stable" "wiki:variant" "beta to stable promotion"
+assert_not_contains "$promoted_stable" "[Beta]" "beta to stable promotion"
+
+echo "▸ Checking wiki publish preservation..."
+publish_rendered="$tmp/publish-rendered"
+publish_remote="$tmp/publish-remote"
+mkdir -p "$publish_rendered" "$publish_remote/.git"
+printf '%s\n' '# Home' > "$publish_rendered/Home.md"
+printf '%s\n' 'remote footer' > "$publish_remote/_Footer.md"
+printf '%s\n' '# Old Page' > "$publish_remote/Old.md"
+rsync -a --delete --exclude='.git/' --exclude='_Footer.md' "$publish_rendered/" "$publish_remote/"
+[ -f "$publish_remote/_Footer.md" ] || fail "wiki publish removed _Footer.md"
+[ ! -f "$publish_remote/Old.md" ] || fail "wiki publish kept stale managed page"
+[ -f "$publish_remote/Home.md" ] || fail "wiki publish did not copy rendered page"
+
+echo "✓ Wiki script fixture tests passed."

--- a/scripts/wiki-check.sh
+++ b/scripts/wiki-check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Validate wiki markers, links, and PR approval requirements.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ruby scripts/wiki-tool.rb check "$@"

--- a/scripts/wiki-promote.sh
+++ b/scripts/wiki-promote.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Promote wiki lifecycle markers from nightly to beta, or beta to stable.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ruby scripts/wiki-tool.rb promote "$@"

--- a/scripts/wiki-render.sh
+++ b/scripts/wiki-render.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Render the repository wiki mirror into publishable GitHub wiki Markdown.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ruby scripts/wiki-tool.rb render "$@"

--- a/scripts/wiki-tool.rb
+++ b/scripts/wiki-tool.rb
@@ -1,0 +1,559 @@
+#!/usr/bin/env ruby
+# Internal helper for wiki marker validation, rendering, promotion, and PR summaries.
+
+require "fileutils"
+require "open3"
+require "optparse"
+require "shellwords"
+require "tmpdir"
+
+ROOT = File.expand_path("..", __dir__)
+DEFAULT_SOURCE = "docs/wiki"
+CHANNEL_RANK = { "stable" => 0, "beta" => 1, "nightly" => 2 }.freeze
+STICKY_MARKER = "<!-- contained-wiki-pr -->"
+
+class WikiError < StandardError; end
+
+Block = Struct.new(:kind, :attrs, :file, :start_line, :end_line, :body_lines, keyword_init: true) do
+  def id
+    attrs["id"]
+  end
+
+  def channel
+    attrs["channel"]
+  end
+
+  def since
+    attrs["since"]
+  end
+end
+
+class WikiDoc
+  attr_reader :source, :files, :blocks, :errors
+
+  def initialize(source)
+    @source = File.expand_path(source, ROOT)
+    @files = Dir.glob(File.join(@source, "*.md")).sort
+    @blocks = []
+    @errors = []
+  end
+
+  def parse
+    files.each { |file| parse_file(file) }
+    validate_blocks
+    validate_links
+    self
+  end
+
+  def relative_path(path)
+    PathnameSafe.relative_path(path, source)
+  end
+
+  private
+
+  def parse_file(file)
+    lines = File.readlines(file, chomp: true)
+    open_block = nil
+    open_body = []
+
+    lines.each_with_index do |line, index|
+      line_number = index + 1
+      if (match = line.match(/\A\s*<!--\s*wiki:(section|variant)\s+(.+?)\s*-->\s*\z/))
+        if open_block
+          errors << "#{relative_path(file)}:#{line_number}: nested wiki block inside #{open_block.kind} '#{open_block.id}'"
+          next
+        end
+
+        attrs = parse_attrs(match[2], file, line_number)
+        open_block = Block.new(
+          kind: match[1],
+          attrs: attrs,
+          file: file,
+          start_line: line_number,
+          body_lines: []
+        )
+        open_body = []
+      elsif (match = line.match(/\A\s*<!--\s*\/wiki:(section|variant)\s*-->\s*\z/))
+        unless open_block
+          errors << "#{relative_path(file)}:#{line_number}: closing wiki #{match[1]} without an opening marker"
+          next
+        end
+        if open_block.kind != match[1]
+          errors << "#{relative_path(file)}:#{line_number}: closing wiki #{match[1]} does not match open #{open_block.kind}"
+          next
+        end
+
+        open_block.end_line = line_number
+        open_block.body_lines = open_body
+        blocks << open_block
+        open_block = nil
+        open_body = []
+      elsif open_block
+        open_body << line
+      end
+    end
+
+    if open_block
+      errors << "#{relative_path(file)}:#{open_block.start_line}: wiki #{open_block.kind} '#{open_block.id}' is missing a closing marker"
+    end
+  end
+
+  def parse_attrs(raw, file, line_number)
+    attrs = {}
+    scanner = raw.dup
+
+    until scanner.strip.empty?
+      scanner = scanner.lstrip
+      match = scanner.match(/\A([a-zA-Z_][a-zA-Z0-9_-]*)="([^"]*)"/)
+      unless match
+        errors << "#{relative_path(file)}:#{line_number}: malformed wiki marker attributes"
+        break
+      end
+
+      key = match[1]
+      value = match[2]
+      if attrs.key?(key)
+        errors << "#{relative_path(file)}:#{line_number}: duplicate wiki marker attribute '#{key}'"
+      end
+      attrs[key] = value
+      scanner = scanner[match[0].length..] || ""
+    end
+
+    attrs
+  end
+
+  def validate_blocks
+    sections_by_id = {}
+    variants_by_key = {}
+
+    blocks.each do |block|
+      if block.id.to_s.empty?
+        errors << "#{relative_path(block.file)}:#{block.start_line}: wiki #{block.kind} is missing id"
+      end
+
+      case block.kind
+      when "section"
+        if sections_by_id.key?(block.id)
+          other = sections_by_id.fetch(block.id)
+          errors << "#{relative_path(block.file)}:#{block.start_line}: duplicate wiki section id '#{block.id}' already declared at #{relative_path(other.file)}:#{other.start_line}"
+        else
+          sections_by_id[block.id] = block
+        end
+      when "variant"
+        unless %w[beta nightly].include?(block.channel)
+          errors << "#{relative_path(block.file)}:#{block.start_line}: wiki variant '#{block.id}' must use channel beta or nightly"
+        end
+        if block.since.to_s.empty?
+          errors << "#{relative_path(block.file)}:#{block.start_line}: wiki variant '#{block.id}' is missing since"
+        end
+
+        key = [block.id, block.channel]
+        if variants_by_key.key?(key)
+          other = variants_by_key.fetch(key)
+          errors << "#{relative_path(block.file)}:#{block.start_line}: duplicate #{block.channel} wiki variant '#{block.id}' already declared at #{relative_path(other.file)}:#{other.start_line}"
+        else
+          variants_by_key[key] = block
+        end
+
+        label = "[#{block.channel.capitalize}]"
+        first_content = block.body_lines.find { |body_line| !body_line.strip.empty? }.to_s
+        unless first_content.include?(label)
+          errors << "#{relative_path(block.file)}:#{block.start_line}: wiki variant '#{block.id}' should start with a visible #{label} label"
+        end
+      end
+    end
+
+    blocks.select { |block| block.kind == "variant" }.each do |variant|
+      section = sections_by_id[variant.id]
+      if section.nil?
+        errors << "#{relative_path(variant.file)}:#{variant.start_line}: wiki variant '#{variant.id}' has no matching wiki section"
+      elsif section.file != variant.file
+        errors << "#{relative_path(variant.file)}:#{variant.start_line}: wiki variant '#{variant.id}' must live in the same file as its section"
+      elsif section.start_line > variant.start_line
+        errors << "#{relative_path(variant.file)}:#{variant.start_line}: wiki variant '#{variant.id}' must appear below its stable section"
+      end
+    end
+  end
+
+  def validate_links
+    page_names = files.map { |file| File.basename(file, ".md") }.to_set
+    files.each do |file|
+      File.readlines(file, chomp: true).each_with_index do |line, index|
+        line.scan(/\[\[([^\]]+)\]\]/).flatten.each do |raw_target|
+          target = raw_target.split("|", 2).last.to_s.split("#", 2).first.to_s.strip
+          next if target.empty?
+
+          candidates = [target, target.tr(" ", "-")]
+          next if candidates.any? { |candidate| page_names.include?(candidate) }
+
+          errors << "#{relative_path(file)}:#{index + 1}: broken wiki link [[#{raw_target}]]"
+        end
+      end
+    end
+  end
+end
+
+module PathnameSafe
+  module_function
+
+  def relative_path(path, base)
+    path = File.expand_path(path)
+    base = File.expand_path(base)
+    path.sub(/\A#{Regexp.escape(base)}\/?/, "")
+  end
+end
+
+def require_set
+  require "set"
+end
+
+def fail_with(errors)
+  errors.each { |error| warn "x #{error}" }
+  raise WikiError, "#{errors.length} wiki validation #{errors.length == 1 ? "error" : "errors"}"
+end
+
+def parse_doc!(source)
+  require_set
+  doc = WikiDoc.new(source).parse
+  fail_with(doc.errors) unless doc.errors.empty?
+  doc
+end
+
+def display_channel(channel)
+  channel.capitalize
+end
+
+def included_variant?(variant, channel)
+  CHANNEL_RANK.fetch(variant.channel) <= CHANNEL_RANK.fetch(channel)
+end
+
+def render_section(body_lines, variants)
+  return body_lines if variants.empty?
+
+  labels = variants.map { |variant| "[#{display_channel(variant.channel)}]" }.uniq
+  since_values = variants.map(&:since).compact.reject(&:empty?).uniq
+  since = since_values.length == 1 ? " in #{since_values.first}" : ""
+  replacement_word = labels.length == 1 ? "replacement" : "replacements"
+  label_text = labels.length == 1 ? labels.first : "#{labels[0..-2].join(", ")} and #{labels[-1]}"
+  notice = [
+    "",
+    "> [!WARNING]",
+    "> **Deprecating#{since}.** See the #{label_text} #{replacement_word} below.",
+    ""
+  ]
+
+  output = []
+  inserted = false
+  body_lines.each do |line|
+    output << line
+    next if inserted
+
+    if line.match?(/\A#{'#'}{1,6}\s+/)
+      output.concat(notice)
+      inserted = true
+    end
+  end
+
+  output = notice + output unless inserted
+  output
+end
+
+def render_file(path, doc, channel)
+  lines = File.readlines(path, chomp: true)
+  blocks = doc.blocks.select { |block| block.file == path }.sort_by(&:start_line)
+  variants_by_id = blocks
+    .select { |block| block.kind == "variant" && included_variant?(block, channel) }
+    .group_by(&:id)
+
+  output = []
+  cursor = 1
+  blocks.each do |block|
+    next if block.start_line < cursor
+
+    output.concat(lines[(cursor - 1)...(block.start_line - 1)] || [])
+
+    case block.kind
+    when "section"
+      output.concat(render_section(block.body_lines, variants_by_id.fetch(block.id, [])))
+    when "variant"
+      output.concat(block.body_lines) if included_variant?(block, channel)
+    end
+
+    cursor = block.end_line + 1
+  end
+  output.concat(lines[(cursor - 1)..] || [])
+  "#{output.join("\n")}\n"
+end
+
+def command_render(argv)
+  options = { source: DEFAULT_SOURCE, output: nil, channel: "nightly" }
+  parser = OptionParser.new do |opts|
+    opts.on("--source PATH") { |value| options[:source] = value }
+    opts.on("--output PATH") { |value| options[:output] = value }
+    opts.on("--channel CHANNEL") { |value| options[:channel] = value }
+  end
+  parser.parse!(argv)
+
+  raise WikiError, "--output is required" if options[:output].to_s.empty?
+  raise WikiError, "unknown channel '#{options[:channel]}'" unless CHANNEL_RANK.key?(options[:channel])
+
+  doc = parse_doc!(options[:source])
+  output_dir = File.expand_path(options[:output], ROOT)
+  FileUtils.rm_rf(output_dir)
+  FileUtils.mkdir_p(output_dir)
+
+  doc.files.each do |path|
+    rendered = render_file(path, doc, options[:channel])
+    File.write(File.join(output_dir, File.basename(path)), rendered)
+  end
+
+  puts "✓ Rendered wiki to #{PathnameSafe.relative_path(output_dir, ROOT)} (#{options[:channel]})"
+end
+
+def section_variant_ids(source)
+  return { sections: Set.new, variants: Set.new } unless File.exist?(source)
+
+  sections = Set.new
+  variants = Set.new
+  File.read(source).scan(/<!--\s*wiki:(section|variant)\s+(.+?)\s*-->/).each do |kind, raw_attrs|
+    attrs = {}
+    raw_attrs.scan(/([a-zA-Z_][a-zA-Z0-9_-]*)="([^"]*)"/).each { |key, value| attrs[key] = value }
+    if kind == "section"
+      sections << attrs["id"] if attrs["id"]
+    else
+      variants << "#{attrs["id"]}:#{attrs["channel"]}" if attrs["id"] && attrs["channel"]
+    end
+  end
+  { sections: sections, variants: variants }
+end
+
+def git_changed_files(base_ref, head_ref)
+  return [] if base_ref.to_s.empty?
+
+  output, status = Open3.capture2("git", "diff", "--name-status", "#{base_ref}...#{head_ref}")
+  raise WikiError, "git diff failed for #{base_ref}...#{head_ref}" unless status.success?
+
+  output.lines.map do |line|
+    status_code, path = line.chomp.split(/\s+/, 2)
+    [status_code, path]
+  end
+end
+
+def git_file(ref, path)
+  output, status = Open3.capture2("git", "show", "#{ref}:#{path}")
+  status.success? ? output : nil
+end
+
+def write_summary(path, lines)
+  return if path.to_s.empty?
+
+  FileUtils.mkdir_p(File.dirname(path))
+  File.write(path, "#{lines.join("\n")}\n")
+end
+
+def command_check(argv)
+  options = {
+    source: DEFAULT_SOURCE,
+    base_ref: nil,
+    head_ref: "HEAD",
+    summary_file: nil,
+    require_approval: false,
+    approved: false
+  }
+  parser = OptionParser.new do |opts|
+    opts.on("--source PATH") { |value| options[:source] = value }
+    opts.on("--base-ref REF") { |value| options[:base_ref] = value }
+    opts.on("--head-ref REF") { |value| options[:head_ref] = value }
+    opts.on("--summary-file PATH") { |value| options[:summary_file] = value }
+    opts.on("--require-approval") { options[:require_approval] = true }
+    opts.on("--approved") { options[:approved] = true }
+  end
+  parser.parse!(argv)
+
+  require_set
+  errors = WikiDoc.new(options[:source]).parse.errors
+
+  changed = git_changed_files(options[:base_ref], options[:head_ref])
+  changed_paths = changed.map(&:last).compact
+  changed_wiki = changed_paths.select { |path| path.start_with?("docs/wiki/") }
+  source_like = changed_paths.select do |path|
+    path.start_with?("Sources/", "Tests/", "scripts/", ".github/workflows/") ||
+      %w[Package.swift Package.resolved README.md AGENTS.md].include?(path)
+  end
+  needs_advisory = changed_wiki.empty? && !source_like.empty?
+
+  page_changes = changed_wiki.map { |path| path.delete_prefix("docs/wiki/") }.sort
+  added_sections = Set.new
+  removed_sections = Set.new
+  added_variants = Set.new
+  removed_variants = Set.new
+
+  changed_wiki.each do |path|
+    old_content = options[:base_ref] ? git_file(options[:base_ref], path) : nil
+    new_content = File.exist?(path) ? File.read(path) : nil
+    old_ids = section_variant_ids_from_content(old_content)
+    new_ids = section_variant_ids_from_content(new_content)
+    added_sections.merge(new_ids[:sections] - old_ids[:sections])
+    removed_sections.merge(old_ids[:sections] - new_ids[:sections])
+    added_variants.merge(new_ids[:variants] - old_ids[:variants])
+    removed_variants.merge(old_ids[:variants] - new_ids[:variants])
+  end
+
+  approval_missing = options[:require_approval] && !changed_wiki.empty? && !options[:approved]
+  errors << "wiki-approved label is required for docs/wiki changes" if approval_missing
+
+  summary = []
+  summary << STICKY_MARKER
+  summary << "## Wiki Review"
+  summary << ""
+  if changed_wiki.empty?
+    summary << "- Wiki pages changed: none"
+  else
+    summary << "- Wiki pages changed: #{page_changes.join(", ")}"
+  end
+  summary << "- Approval: #{changed_wiki.empty? ? "not required" : (options[:approved] ? "wiki-approved present" : "wiki-approved missing")}"
+  summary << "- Source-only advisory: #{needs_advisory ? "review whether docs/wiki needs an update" : "not needed"}"
+  summary << "- Added section ids: #{added_sections.empty? ? "none" : added_sections.to_a.sort.join(", ")}"
+  summary << "- Removed section ids: #{removed_sections.empty? ? "none" : removed_sections.to_a.sort.join(", ")}"
+  summary << "- Added variants: #{added_variants.empty? ? "none" : added_variants.to_a.sort.join(", ")}"
+  summary << "- Removed variants: #{removed_variants.empty? ? "none" : removed_variants.to_a.sort.join(", ")}"
+  summary << ""
+  summary << "Rendered preview and diff are attached as the `wiki-preview` artifact when this workflow runs in GitHub Actions."
+  summary << ""
+  if errors.empty?
+    summary << "Status: passed."
+  else
+    summary << "Status: failed."
+    errors.each { |error| summary << "- #{error}" }
+  end
+  write_summary(options[:summary_file], summary)
+
+  if errors.empty?
+    puts "✓ Wiki check passed."
+  else
+    fail_with(errors)
+  end
+end
+
+def section_variant_ids_from_content(content)
+  return { sections: Set.new, variants: Set.new } if content.nil?
+
+  sections = Set.new
+  variants = Set.new
+  content.scan(/<!--\s*wiki:(section|variant)\s+(.+?)\s*-->/).each do |kind, raw_attrs|
+    attrs = {}
+    raw_attrs.scan(/([a-zA-Z_][a-zA-Z0-9_-]*)="([^"]*)"/).each { |key, value| attrs[key] = value }
+    if kind == "section"
+      sections << attrs["id"] if attrs["id"]
+    else
+      variants << "#{attrs["id"]}:#{attrs["channel"]}" if attrs["id"] && attrs["channel"]
+    end
+  end
+  { sections: sections, variants: variants }
+end
+
+def command_promote(argv)
+  options = { source: DEFAULT_SOURCE, from: nil, to: nil }
+  parser = OptionParser.new do |opts|
+    opts.on("--source PATH") { |value| options[:source] = value }
+    opts.on("--from CHANNEL") { |value| options[:from] = value }
+    opts.on("--to CHANNEL") { |value| options[:to] = value }
+  end
+  parser.parse!(argv)
+
+  unless [%w[nightly beta], %w[beta stable]].include?([options[:from], options[:to]])
+    raise WikiError, "supported promotions are nightly -> beta and beta -> stable"
+  end
+
+  doc = parse_doc!(options[:source])
+  changed_files = []
+
+  doc.files.each do |path|
+    blocks = doc.blocks.select { |block| block.file == path }.sort_by(&:start_line)
+    next if blocks.empty?
+
+    lines = File.readlines(path, chomp: true)
+    next_lines = if options[:from] == "nightly"
+      promote_nightly_to_beta(lines, blocks)
+    else
+      promote_beta_to_stable(lines, blocks)
+    end
+
+    next if next_lines == lines
+
+    File.write(path, "#{next_lines.join("\n")}\n")
+    changed_files << PathnameSafe.relative_path(path, ROOT)
+  end
+
+  if changed_files.empty?
+    puts "No #{options[:from]} wiki variants were found to promote."
+  else
+    puts "✓ Promoted wiki variants in #{changed_files.join(", ")}"
+  end
+end
+
+def promote_nightly_to_beta(lines, blocks)
+  output = lines.dup
+  blocks.select { |block| block.kind == "variant" && block.channel == "nightly" }.each do |block|
+    output[block.start_line - 1] = output[block.start_line - 1].sub('channel="nightly"', 'channel="beta"')
+    ((block.start_line)...(block.end_line - 1)).each do |line_index|
+      next unless output[line_index].match?(/\A#{'#'}{1,6}\s+/)
+
+      output[line_index] = output[line_index].sub("[Nightly]", "[Beta]")
+      break
+    end
+  end
+  output
+end
+
+def strip_channel_label(lines, channel)
+  label = "[#{display_channel(channel)}]"
+  lines.map do |line|
+    line.match?(/\A#{'#'}{1,6}\s+/) ? line.sub(/\s*#{Regexp.escape(label)}\s*/, " ") : line
+  end
+end
+
+def promote_beta_to_stable(lines, blocks)
+  beta_variants = blocks.select { |block| block.kind == "variant" && block.channel == "beta" }.group_by(&:id)
+  return lines if beta_variants.empty?
+
+  output = []
+  cursor = 1
+  blocks.each do |block|
+    next if block.start_line < cursor
+
+    output.concat(lines[(cursor - 1)...(block.start_line - 1)] || [])
+
+    if block.kind == "section" && beta_variants.key?(block.id)
+      output << lines[block.start_line - 1]
+      output.concat(strip_channel_label(beta_variants.fetch(block.id).first.body_lines, "beta"))
+      output << lines[block.end_line - 1]
+    elsif block.kind == "variant" && block.channel == "beta"
+      # Drop promoted beta variants after replacing their stable section.
+    else
+      output.concat(lines[(block.start_line - 1)..(block.end_line - 1)] || [])
+    end
+
+    cursor = block.end_line + 1
+  end
+  output.concat(lines[(cursor - 1)..] || [])
+  output
+end
+
+def usage!
+  warn "Usage: scripts/wiki-tool.rb <check|render|promote> [options]"
+  exit 2
+end
+
+begin
+  command = ARGV.shift || usage!
+  case command
+  when "check" then command_check(ARGV)
+  when "render" then command_render(ARGV)
+  when "promote" then command_promote(ARGV)
+  else usage!
+  end
+rescue WikiError => error
+  warn "x #{error.message}"
+  exit 1
+end


### PR DESCRIPTION
## Summary
- add wiki marker validation, rendering, and promotion scripts
- add PR wiki guard with sticky comments, preview artifacts, and wiki-approved label enforcement
- add nightly wiki sync publishing workflow that preserves wiki-only footer files
- document docs/wiki as the canonical GitHub wiki source

## Validation
- ./scripts/ci-validate.sh
- ./scripts/test-release-scripts.sh
- ./scripts/test-wiki-scripts.sh
- ./scripts/wiki-check.sh --base-ref origin/nightly --head-ref HEAD --summary-file .release/wiki-gate-approved.md --require-approval --approved
- ./scripts/check-generated-clean.sh
- swift build -c release

## Note
Leaving this PR unmerged until explicitly approved.