### PR TITLE
Improve GitHub contributor setup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,8 @@
 
 The full contributing guide lives in the project wiki:
 
-👉 **https://github.com/tdeverx/contained-app/wiki/Contributing**
+- **Contributing:** https://github.com/tdeverx/contained-app/wiki/Contributing
+- **Issues and Discussions:** https://github.com/tdeverx/contained-app/wiki/Issues-and-Discussions
 
 By contributing, you agree your work is licensed under the project's
 [PolyForm Noncommercial License 1.0.0](../LICENSE) — non-commercial use only.

--- a/.github/ISSUE_TEMPLATE/backend_runtime.yml
+++ b/.github/ISSUE_TEMPLATE/backend_runtime.yml
@@ -1,0 +1,64 @@
+name: Backend or runtime work
+description: Apple container, Docker compatibility, command abstraction, compose, or runtime behavior
+title: "[Backend]: "
+labels: ["feature", "backend", "triage"]
+body:
+  - type: textarea
+    id: runtime-area
+    attributes:
+      label: Runtime area
+      description: What backend, command, data model, or runtime behavior is involved?
+      placeholder: Apple container, Docker, compose, images, networks, volumes, command building...
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What capability or abstraction should exist when this is done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: research-design
+    attributes:
+      label: Research / design checklist
+      description: What should be answered before implementation starts?
+      placeholder: |
+        - [ ] Inventory affected ContainerCommands and ContainerClient call sites
+        - [ ] Identify Apple container compatibility requirements
+        - [ ] Note Docker or future-backend differences
+    validations:
+      required: false
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation checklist
+      description: What likely needs to change?
+      placeholder: |
+        - [ ] Keep CLI actions behind ContainerCommands and ContainerClient
+        - [ ] Put pure decisions in ContainedCore
+        - [ ] Add focused tests
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Existing Apple container behavior stays compatible
+        - [ ] SwiftUI does not assemble backend argv inline
+        - [ ] Unsupported backend capabilities are handled clearly
+    validations:
+      required: false
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related links, blockers, or compatibility notes
+      description: Issues, docs, commands, migration concerns, backend-specific notes, known blockers, or a suggested milestone.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,56 +1,74 @@
 name: Bug report
-description: Something isn't working as expected
+description: Something is not working as expected
 title: "[Bug]: "
-labels: ["bug"]
+labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for taking the time to file a bug! Please fill out the details below so it can be reproduced.
+      value: |
+        Thanks for taking the time to report this. A short, clear report is enough; fill in what you know and leave the rest blank.
+
   - type: textarea
-    id: what-happened
+    id: summary
     attributes:
       label: What happened?
-      description: A clear description of the bug, and what you expected instead.
-      placeholder: When I…, I expected…, but instead…
+      description: What did you try, what did you expect, and what happened instead?
+      placeholder: I tried to..., expected..., but...
     validations:
       required: true
+
   - type: textarea
-    id: repro
+    id: steps
     attributes:
       label: Steps to reproduce
+      description: A small repeatable path is ideal. If it only happened once, describe the flow as best you can.
       placeholder: |
-        1. Go to…
-        2. Click…
-        3. See…
+        1. Open...
+        2. Click...
+        3. See...
     validations:
-      required: true
+      required: false
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: How much does this block you?
+      placeholder: Blocks the task completely / annoying but workable / visual only / not sure
+    validations:
+      required: false
+
   - type: input
     id: app-version
     attributes:
       label: Contained version
-      description: From the menu bar — Contained ▸ About Contained.
-      placeholder: e.g. 1.0.0-beta.1 (build 21)
+      description: From Contained > About Contained, or the commit/branch if running from source.
+      placeholder: "1.0.0-nightly.88+c26d7b3"
     validations:
-      required: true
+      required: false
+
   - type: input
     id: macos
     attributes:
       label: macOS version
-      placeholder: e.g. macOS 26.0
+      placeholder: "macOS 26.0"
     validations:
-      required: true
+      required: false
+
   - type: input
     id: cli-version
     attributes:
-      label: container CLI version
-      description: Output of `container --version`.
-      placeholder: e.g. 1.0.0
+      label: Apple container CLI version
+      description: Output of `container --version`, if this touches container operations.
+      placeholder: "1.0.0"
     validations:
       required: false
+
   - type: textarea
     id: logs
     attributes:
-      label: Logs / screenshots
-      description: Any relevant log output or screenshots. "Reveal CLI" output is especially helpful.
+      label: Logs, screenshots, or Reveal CLI output
+      description: Paste only what you are comfortable sharing. Please remove tokens, private paths, and personal data.
+      render: text
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,20 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 📖 Documentation (Wiki)
+  - name: Documentation (Wiki)
     url: https://github.com/tdeverx/contained-app/wiki
     about: Features, installation, and architecture.
-  - name: 🛠 Troubleshooting
+  - name: Troubleshooting
     url: https://github.com/tdeverx/contained-app/wiki/Troubleshooting
     about: Common issues and fixes — please check here before filing a bug.
+  - name: Help and Q&A
+    url: https://github.com/tdeverx/contained-app/discussions/categories/q-a
+    about: Setup help, usage questions, and unclear behavior that is not yet an actionable bug.
+  - name: Ideas and early proposals
+    url: https://github.com/tdeverx/contained-app/discussions/categories/ideas
+    about: Product ideas and rough proposals before they become tracked issues.
+  - name: Development and architecture
+    url: https://github.com/tdeverx/contained-app/discussions/30
+    about: Package boundaries, design-system direction, navigation, backend, release-process, and automation design.
+  - name: Show and tell
+    url: https://github.com/tdeverx/contained-app/discussions/categories/show-and-tell
+    about: Share what you are building or how you use Contained.

--- a/.github/ISSUE_TEMPLATE/crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/crash_report.yml
@@ -1,0 +1,59 @@
+name: Crash report
+description: Contained quits, freezes, or shows a crash report
+title: "[Crash]: "
+labels: ["bug", "high", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Crash reports are extremely useful. Please remove anything private before posting logs.
+
+  - type: textarea
+    id: crash-summary
+    attributes:
+      label: What were you doing?
+      description: Describe the last few actions before the crash or freeze.
+      placeholder: I opened..., clicked..., then Contained...
+    validations:
+      required: true
+
+  - type: textarea
+    id: repeatability
+    attributes:
+      label: Can you make it happen again?
+      placeholder: Always / sometimes / only happened once / not sure
+    validations:
+      required: false
+
+  - type: textarea
+    id: crash-log
+    attributes:
+      label: Crash report or relevant log
+      description: Paste the top crashed thread and exception details, or attach the crash report.
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: app-version
+    attributes:
+      label: Contained version
+      placeholder: "1.0.0-nightly.88+c26d7b3"
+    validations:
+      required: false
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      placeholder: "macOS 26.0"
+    validations:
+      required: false
+
+  - type: textarea
+    id: attachments
+    attributes:
+      label: Screenshots or extra context
+      description: Anything else that helps explain the crash.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/design_system.yml
+++ b/.github/ISSUE_TEMPLATE/design_system.yml
@@ -1,0 +1,73 @@
+name: Design system work
+description: Shared controls, cards, scaffolds, materials, or visual primitives
+title: "[Design System]: "
+labels: ["feature", "design", "needs-design"]
+body:
+  - type: textarea
+    id: surface
+    attributes:
+      label: Surface or primitive
+      description: What shared UI element or pattern should change?
+      placeholder: Buttons, cards, settings rows, panel scaffold, command preview...
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is inconsistent, missing, hard to reuse, or hard to understand?
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: Describe the target behavior, reuse boundary, or visual standard.
+    validations:
+      required: false
+
+  - type: textarea
+    id: research-design
+    attributes:
+      label: Research / design checklist
+      description: What should be checked before implementation starts?
+      placeholder: |
+        - [ ] Inventory affected call sites
+        - [ ] Decide which behavior belongs in the shared primitive
+        - [ ] Confirm Settings/docs impact
+    validations:
+      required: false
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation checklist
+      description: What likely needs to change?
+      placeholder: |
+        - [ ] Move shared behavior into the primitive
+        - [ ] Remove duplicated local styling where appropriate
+        - [ ] Update docs/wiki if behavior or language changes
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Shared primitive is reusable from the expected screens
+        - [ ] App-specific state stays outside reusable UI
+        - [ ] Existing screens keep their intended behavior
+    validations:
+      required: false
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related links, blockers, or affected areas
+      description: Screens, issues, discussions, docs, examples, known blockers, or a suggested milestone.
+      placeholder: Containers, Images, Settings, toolbar panels, creation flow...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,26 +1,82 @@
-name: Feature request
-description: Suggest an idea or improvement
+name: Feature proposal
+description: Suggest a product improvement that is ready to become tracked work
 title: "[Feature]: "
-labels: ["enhancement"]
+labels: ["feature", "triage"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the idea is concrete enough to track. If it is still exploratory, start a Discussion or use the exploration template.
+
   - type: textarea
     id: problem
     attributes:
-      label: What problem does this solve?
-      description: What are you trying to do that's hard or impossible today?
+      label: Problem or opportunity
+      description: What are you trying to do that is hard, confusing, or missing today?
+      placeholder: I want to..., but today...
     validations:
       required: true
+
   - type: textarea
-    id: solution
+    id: proposal
     attributes:
-      label: Proposed solution
-      description: What would you like to see happen?
+      label: Proposed behavior
+      description: What should Contained do when this is finished?
+      placeholder: The app should...
     validations:
       required: true
+
   - type: textarea
-    id: alternatives
+    id: context
     attributes:
-      label: Alternatives considered
-      description: Other approaches or workarounds you've thought about.
+      label: Context or workflow
+      description: Links, examples, current workarounds, or the expected user flow.
+      placeholder: |
+        - Related discussion:
+        - Current workaround:
+        - Expected flow:
+    validations:
+      required: false
+
+  - type: textarea
+    id: research-design
+    attributes:
+      label: Research / design checklist
+      description: What should be answered before implementation starts?
+      placeholder: |
+        - [ ] Compare the main options
+        - [ ] Check affected screens, commands, or settings
+        - [ ] Confirm docs/wiki impact
+    validations:
+      required: false
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation checklist
+      description: What likely needs to change?
+      placeholder: |
+        - [ ] Update the relevant app/core code
+        - [ ] Add or update focused tests
+        - [ ] Update docs/wiki if behavior or language changes
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What would make this feel done?
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related links, blockers, or target
+      description: Discussions, issues, docs, examples, prior art, known blockers, or a suggested milestone.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/navigation_tooling.yml
+++ b/.github/ISSUE_TEMPLATE/navigation_tooling.yml
@@ -1,0 +1,72 @@
+name: Navigation, toolbar, or panel work
+description: Page routing, toolbars, panels, morphs, measurements, or shell behavior
+title: "[Navigation]: "
+labels: ["feature", "navigation", "triage"]
+body:
+  - type: textarea
+    id: area
+    attributes:
+      label: Navigation area
+      description: What part of the shell, toolbar, panel system, or page flow is involved?
+      placeholder: Sidebar fallback, toolbar panel, plus morph, page filters, measurement system...
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or goal
+      description: What should feel better, become reusable, or be fixed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Note classic-sidebar fallback, native macOS behavior, measurement, animation, or accessibility requirements.
+    validations:
+      required: false
+
+  - type: textarea
+    id: research-design
+    attributes:
+      label: Research / design checklist
+      description: What should be decided before implementation starts?
+      placeholder: |
+        - [ ] Identify affected routes, panels, or toolbar surfaces
+        - [ ] Decide what belongs in reusable navigation infrastructure
+        - [ ] Confirm classic-sidebar and toolbar-first behavior
+    validations:
+      required: false
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation checklist
+      description: What likely needs to change?
+      placeholder: |
+        - [ ] Update navigation, toolbar, panel, or measurement code
+        - [ ] Add focused tests or smoke coverage where practical
+        - [ ] Update docs/wiki if behavior or terminology changes
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: |
+        - [ ] Classic sidebar still works
+        - [ ] Toolbar-first path works
+        - [ ] UI smoke-tested in Contained.app
+    validations:
+      required: false
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related links, blockers, or target
+      description: Issues, discussions, docs, known blockers, or a suggested milestone.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/research_exploration.yml
+++ b/.github/ISSUE_TEMPLATE/research_exploration.yml
@@ -1,0 +1,73 @@
+name: Exploration or decision
+description: Investigate an idea, technical option, API, or design direction
+title: "[Explore]: "
+labels: ["other", "needs-design"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question to answer
+      description: What decision should this exploration help us make?
+      placeholder: Should Contained...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why does this matter now?
+    validations:
+      required: false
+
+  - type: textarea
+    id: exploration-tasks
+    attributes:
+      label: Research / design checklist
+      placeholder: |
+        - [ ] Review...
+        - [ ] Compare...
+        - [ ] Summarize tradeoffs...
+    validations:
+      required: false
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation checklist
+      description: What follow-up work should happen if the recommendation is accepted?
+      placeholder: |
+        - [ ] Post the recommendation and tradeoffs
+        - [ ] Create or update follow-up implementation issues
+        - [ ] Update docs/wiki if policy or workflow changes
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: What would make the exploration complete?
+      placeholder: |
+        - [ ] Recommendation is clear
+        - [ ] Risks and alternatives are documented
+        - [ ] Next step is filed, linked, or explicitly rejected
+    validations:
+      required: false
+
+  - type: textarea
+    id: sources
+    attributes:
+      label: Known sources, links, or blockers
+      description: Include docs, issues, examples, prior discussions, known blockers, or a suggested milestone if available.
+    validations:
+      required: false
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Expected output
+      description: What should the final comment or follow-up issue contain?
+      placeholder: Recommendation, links, risks, next implementation issue...
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - other
+      - repo
+
+  - package-ecosystem: swift
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    groups:
+      swift-packages:
+        patterns:
+          - "*"
+    labels:
+      - other
+      - core

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,15 +2,27 @@
 
 - 
 
-## Checks
+## Linked Issue
 
+- Closes #
+- No linked issue because:
+- [ ] This PR links an issue, or explains why one is not needed
+
+## Change Type
+
+- [ ] App/UI behavior
+- [ ] Core/runtime logic
+- [ ] Release, workflow, or script behavior
+- [ ] Docs, issue templates, or repository metadata only
+
+## Validation
+
+- [ ] `git diff --check`
 - [ ] `./scripts/ci-validate.sh`
-- [ ] `./scripts/test-release-scripts.sh`
 - [ ] `swift build`
 - [ ] `swift test`
-- [ ] `git diff --check`
 - [ ] UI/app changes smoke-tested with `./scripts/bundle.sh debug`
-- [ ] Script/workflow changes covered by `./scripts/ci-validate.sh` and relevant fixture/validator scripts
+- [ ] Release/script changes covered by `./scripts/test-release-scripts.sh` and relevant validators
 
 ## Release Notes And Docs
 
@@ -20,7 +32,11 @@
 
 ## Update Safety
 
-- [ ] Did not compute build numbers outside `scripts/version-info.sh`
-- [ ] Did not remove Nightly's ability to receive promoted Beta/Stable appcast items
-- [ ] Did not introduce generated-file commits that can trigger release loops
-- [ ] Bundle/appcast changes were validated with `scripts/validate-bundle.sh` / `scripts/validate-appcast.sh`
+- [ ] Build numbers still come only from `scripts/version-info.sh`
+- [ ] Nightly can still receive promoted Beta/Stable appcast items
+- [ ] Generated appcast commits still use `[skip ci]` and do not trigger release loops
+- [ ] Bundle/appcast changes were validated with `scripts/validate-bundle.sh` and `scripts/validate-appcast.sh`
+
+## Notes For Reviewers
+
+-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,16 +5,6 @@ name: PR
 on:
   pull_request:
     branches: [main, nightly, beta, stable]
-    paths-ignore:
-      - 'docs/**'
-      - 'README.md'
-      - 'CODE_OF_CONDUCT.md'
-      - '.github/CONTRIBUTING.md'
-      - '.github/assets/**'
-      - 'LICENSE'
-      - 'NOTICE'
-      - '.gitignore'
-      - 'appcast.xml'
 
 concurrency:
   group: pr-${{ github.ref }}
@@ -34,6 +24,24 @@ jobs:
       - name: Toolchain
         run: swift --version && xcodebuild -version
 
+      - name: Classify changes
+        id: changes
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          material=false
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            case "$file" in
+              docs/**|README.md|CODE_OF_CONDUCT.md|.github/CONTRIBUTING.md|.github/assets/**|.github/ISSUE_TEMPLATE/**|LICENSE|NOTICE|SECURITY.md|SUPPORT.md|CODEOWNERS|.github/dependabot.yml|.gitignore|appcast.xml)
+                ;;
+              *)
+                material=true
+                ;;
+            esac
+          done < <(git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD")
+          echo "material=${material}" >> "$GITHUB_OUTPUT"
+
       - name: Repository validation
         env:
           NO_RELEASE_NOTE: ${{ contains(github.event.pull_request.labels.*.name, 'no-release-note') && '1' || '' }}
@@ -43,9 +51,11 @@ jobs:
           ./scripts/ci-validate.sh --base-ref "origin/${{ github.base_ref }}" --require-release-note
 
       - name: Release script fixtures
+        if: steps.changes.outputs.material == 'true'
         run: ./scripts/test-release-scripts.sh
 
       - name: Build & test
+        if: steps.changes.outputs.material == 'true'
         run: |
           set -euo pipefail
           swift build -c release
@@ -53,6 +63,7 @@ jobs:
           ./scripts/check-generated-clean.sh
 
       - name: Bundle smoke validation
+        if: steps.changes.outputs.material == 'true'
         run: |
           set -euo pipefail
           BUILD=$(CHANNEL=nightly ./scripts/version-info.sh build)
@@ -61,3 +72,7 @@ jobs:
           CHANNEL=nightly BUILD="${BUILD}" VERSION="${VERSION}" ./scripts/bundle.sh release
           VERSION="${VERSION}" BUILD="${BUILD}" ./scripts/validate-bundle.sh Contained.app
           ./scripts/check-generated-clean.sh
+
+      - name: Skip build notice
+        if: steps.changes.outputs.material != 'true'
+        run: echo "Docs/community metadata only - build and bundle checks skipped."

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,18 @@
+# Default ownership for all repository changes.
+* @tdeverx
+
+# Core app areas.
+/Sources/ContainedCore/ @tdeverx
+/Sources/Contained/ @tdeverx
+/Tests/ @tdeverx
+
+# Repository operations.
+/.github/ @tdeverx
+/scripts/ @tdeverx
+/docs/ @tdeverx
+/CHANGELOG.md @tdeverx
+/Sources/Contained/Resources/CHANGELOG.md @tdeverx
+
+# Release channels and update feeds.
+/appcast.xml @tdeverx
+/VERSION @tdeverx

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+Contained is pre-1.0 and changes quickly. Security fixes are handled on the
+active `nightly` branch first, then promoted to beta or stable when those
+channels exist.
+
+## Reporting A Vulnerability
+
+Please do not open a public issue for a vulnerability. Email the maintainer or
+use GitHub's private vulnerability reporting when it is available for this
+repository.
+
+Include:
+
+- The affected Contained version or commit.
+- Your macOS version and `container --version` output, if relevant.
+- A clear description of the impact.
+- Reproduction steps or proof-of-concept details.
+- Any logs, screenshots, or command output that help explain the issue.
+
+The maintainer will acknowledge valid reports as soon as practical, keep the
+discussion private while a fix is prepared, and publish notes once the risk is
+resolved.
+
+## Scope
+
+Security reports should focus on Contained itself: app behavior, update flow,
+release artifacts, local data handling, command construction, and repository
+automation. Vulnerabilities in Apple's `container` CLI, macOS, Sparkle, or
+third-party services should also be reported upstream.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,26 @@
+# Support
+
+Thanks for trying Contained. Start with the docs, then choose the smallest
+place that fits what you need.
+
+## Before Opening An Issue
+
+- Check the [wiki](https://github.com/tdeverx/contained-app/wiki).
+- Check [Troubleshooting](https://github.com/tdeverx/contained-app/wiki/Troubleshooting).
+- Search existing issues and discussions.
+
+## Where To Go
+
+- Use Discussions Q&A for setup help, "how do I..." questions, and unclear
+  behavior.
+- Use Ideas for early feature thoughts that are not ready to become tracked
+  work.
+- Use the Development and architecture starter thread in General for package,
+  backend, release-process, and automation design.
+- Use Issues for actionable bugs, crashes, regressions, accepted feature work,
+  architecture tasks, and implementation checklists.
+- Use private security reporting for vulnerabilities. Do not post security
+  details publicly.
+
+If you are unsure, start in Discussions. Maintainers can turn a discussion into
+an issue when it becomes a concrete task.

--- a/changes/unreleased/20260701-github-setup.md
+++ b/changes/unreleased/20260701-github-setup.md
@@ -1,0 +1,1 @@
+- Improved GitHub contributor setup with expanded issue templates, support/security files, discussion guidance, Dependabot configuration, and a PR workflow that still reports the required check for docs-only changes.

--- a/docs/wiki/Contributing.md
+++ b/docs/wiki/Contributing.md
@@ -2,6 +2,51 @@
 
 Forks, issues, and pull requests are welcome. Contained is **source-available** under the [PolyForm Noncommercial License 1.0.0](https://github.com/tdeverx/contained-app/blob/main/LICENSE) — contributions are accepted under those same non-commercial terms, and the "Contained" name and branding are reserved (see [NOTICE](https://github.com/tdeverx/contained-app/blob/main/NOTICE)).
 
+## Issues And Discussions
+
+Start with the [wiki](https://github.com/tdeverx/contained-app/wiki), then choose
+the place that fits:
+
+- Use **Discussions Q&A** for setup help, usage questions, and unclear behavior
+  that is not yet an actionable bug.
+- Use **Ideas** for early product thoughts before there is a concrete task.
+- Use the **Development and architecture** starter thread in General for package
+  boundaries, design-system direction, navigation strategy, backend choices,
+  release process, and automation design until GitHub category setup is
+  customized further.
+- Use **Issues** for bugs, crashes, accepted features, exploration tasks,
+  architecture tasks, and implementation checklists.
+
+Blank issues are disabled. Use the closest issue form so reports stay readable
+and easy to triage. See [[Issues-and-Discussions]] for examples.
+
+For feature, architecture, backend, navigation, design-system, and exploration
+work, issues should include a short goal or context, a research/design checklist,
+an implementation checklist, and acceptance criteria. Bug and crash forms stay
+lighter so reports are not intimidating; maintainers can add implementation
+checklists after triage.
+
+Labels are intentionally short and color-coded. Use one type label (`bug`,
+`feature`, or `other`), add neutral area labels such as `app`, `core`,
+`design`, `navigation`, `backend`, `docker`, `release`, or `repo`, then add a
+status like `triage`, `planned`, `backlog`, `up-next`, `in-progress`,
+`needs-info`, `needs-design`, `released`, `blocked`, or `wont-fix`. Broad
+changes to old issues should be previewed before they are applied. Issue bodies
+should only be rewritten by maintainers or when the original reporter has
+explicitly allowed it.
+
+Use native GitHub relationships for hard sequencing: parent/sub-issues for work
+breakdown, and blocked-by/blocking links when one issue genuinely cannot move
+until another issue is resolved. Keep softer context as plain related links.
+Milestones are target buckets: `beta` for work expected before the next beta,
+`stable` for the first stable-release bar, and `future` for accepted but
+unscheduled or post-beta work.
+
+Release branches (`nightly`, `beta`, and `stable`) are protected against
+deletion and force-pushes. Normal work should move through pull requests. A full
+required-PR/check rule still needs a release-bot-safe bypass before it can be
+enforced without breaking appcast publishing.
+
 ## Layout
 
 ```
@@ -34,8 +79,14 @@ appcast.xml              Sparkle feed at the root of each release branch
 - **Write release notes at the right level.** Put version-wide notes under the base version section, such as `## [1.0.0]`. Put channel/build changes under `Unreleased`, `## [nightly]`, `## [beta]`, or split them into `CHANGES_DIR` fragments. Prefer one fragment per PR/user-facing change under `changes/unreleased/` over one file per commit. `scripts/collect-changes.sh` can compile those fragments for a directory or git range. When no explicit `CHANGES`/`CHANGES_DIR` source is provided, Beta/Nightly notes first try the previous matching appcast item plus the changelog/change-fragment git delta, then fall back to channel sections. Stable ships full notes only; Beta/Nightly ship channel changes plus full notes.
 - **Let CI check invariants, not fix them.** `scripts/ci-validate.sh` checks bundled changelog sync, shell syntax, workflow YAML syntax, Stable/Beta/Nightly release-note ordering, and PR release-note coverage when given a base ref. If `CHANGELOG.md` changes, run `./scripts/sync-changelog-resource.sh` locally and commit the bundled resource; CI uses `--check` so drift fails loudly.
 - **Use `no-release-note` narrowly.** PR CI accepts the label only through `NO_RELEASE_NOTE=1`; reserve it for docs/meta-only work that does not change shipped behavior, scripts, workflows, tests, or source.
+- **Use `wiki-approved` for direct wiki-impacting changes only when a maintainer has reviewed the docs impact.** The wiki sync automation prototype is tracked separately in issue #26 and should not be assumed to exist until that issue is resolved.
 
 ## Before a PR
+
+Link a tracked issue when the PR changes user-facing behavior, architecture,
+runtime/backend behavior, release/workflow policy, security/auth/networking, or
+anything that needed design/research. Tiny docs fixes, dependency bumps, typo
+fixes, and direct review follow-ups can skip the issue when the PR explains why.
 
 ```sh
 ./scripts/ci-validate.sh                       # release/workflow invariants

--- a/docs/wiki/Issues-and-Discussions.md
+++ b/docs/wiki/Issues-and-Discussions.md
@@ -1,0 +1,111 @@
+# Issues and Discussions
+
+Use the smallest place that fits the work. Discussions are for shaping ideas
+and helping people; issues are for tracked work.
+
+## When To Use Discussions
+
+Use Discussions when the topic is open-ended:
+
+- **Q&A**: setup help, "how do I..." questions, and unclear behavior.
+- **Ideas**: early feature thoughts before there is a concrete task.
+- **Development and architecture**: use the starter thread in General for
+  package boundaries, design-system direction, navigation strategy, backend
+  choices, release process, and automation design until GitHub category setup is
+  customized further.
+- **Show and tell**: screenshots, workflows, examples, and experiments.
+- **General**: anything that does not fit elsewhere.
+
+When a discussion becomes concrete, a maintainer can turn it into one or more
+issues with acceptance criteria.
+
+## When To Use Issues
+
+Use issues for work that can be triaged, labeled, and completed:
+
+- Bugs, crashes, and regressions.
+- Accepted feature proposals.
+- Exploration tasks with a clear question to answer.
+- Design-system, navigation, backend, release, or documentation tasks.
+- Parent issues that collect related sub-issues and checklists.
+
+Blank issues are disabled so each report starts with enough structure.
+
+## Good Bug Reports
+
+Helpful bug reports usually include:
+
+- What happened and what you expected instead.
+- Steps to reproduce, if you have them.
+- Contained version, macOS version, and `container --version` when relevant.
+- Screenshots, logs, crash snippets, or Reveal CLI output.
+
+Remove tokens, private paths, and personal data before posting logs.
+
+## Good Feature Proposals
+
+Helpful feature proposals explain:
+
+- The problem or opportunity.
+- The behavior you want Contained to have.
+- The expected user workflow.
+- Acceptance criteria that make the work feel done.
+- Related discussions, issues, or docs.
+
+Early ideas can start in Discussions first.
+
+## Exploration And Architecture Issues
+
+Exploration and architecture issues should name the decision they need to
+support. Good checklists include docs to review, alternatives to compare, risks
+to call out, and the expected output: recommendation, implementation issue, or
+no-go.
+
+Feature, architecture, backend, navigation, design-system, and exploration
+issues should usually include both a research/design checklist and an
+implementation checklist. Bug and crash reports can stay shorter until a
+maintainer has enough context to triage them.
+
+Architecture issues can be parents for smaller implementation issues when the
+work crosses package, navigation, design-system, or backend boundaries.
+
+Use GitHub's native relationship fields when the relationship affects planning:
+
+- Use parent/sub-issues for work breakdown under a larger theme.
+- Use blocked-by/blocking links only when one issue genuinely cannot move until
+  another issue is resolved.
+- Keep softer context, alternatives, and inspiration as plain related links.
+
+Use milestones as target buckets rather than labels:
+
+- `beta`: work expected before the next beta.
+- `stable`: work needed for the first stable-release bar.
+- `future`: accepted work that is unscheduled or likely post-beta.
+
+## Pull Requests
+
+Pull requests should link a tracked issue when they change user-facing behavior,
+architecture, runtime/backend behavior, release/workflow policy,
+security/auth/networking, or anything that needed design/research.
+
+Small docs fixes, dependency bumps, typo fixes, and direct review follow-ups do
+not need a separate issue when the PR explains why. This is guidance, not a
+hard CI gate.
+
+## Labels
+
+Labels are short and color-coded instead of prefixed:
+
+- **Type:** `bug`, `feature`, or `other`.
+- **Area:** neutral labels: `app`, `core`, `design`, `navigation`, `backend`,
+  `docker`, `release`, and `repo`.
+- **Status:** `triage`, `planned`, `backlog`, `up-next`, `in-progress`,
+  `needs-info`, `needs-design`, `released`, `blocked`, or `wont-fix`.
+- **Priority:** `urgent`, `high`, or `low`. No priority label means normal.
+- **Special:** neutral labels such as `duplicate`, `help-wanted`,
+  `good-first-issue`, `no-release-note`, and `wiki-approved`.
+
+Codex may suggest labels, title changes, code pointers, exploration notes, and
+checklists. It may rewrite maintainer-authored issue bodies when asked, but it
+should not rewrite third-party issue bodies, convert a discussion into an issue,
+or make broad issue changes without maintainer approval.

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -52,4 +52,7 @@ Your containers, images, and volumes belong to the `container` runtime and are u
 
 ---
 
-Still stuck? [Open an issue](https://github.com/tdeverx/contained-app/issues).
+Still stuck? Ask in [Discussions Q&A](https://github.com/tdeverx/contained-app/discussions/categories/q-a)
+if you need help understanding the behavior. Open an
+[issue](https://github.com/tdeverx/contained-app/issues/new/choose) when you
+have an actionable bug, crash, regression, or tracked feature request.

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -19,5 +19,6 @@
 - Maintainers
   - [[Architecture]]
   - [[Design System|Design-System]]
-  - [[Contributing]]
   - [[Release]]
+- [[Contributing]]
+- [[Issues-and-Discussions]]


### PR DESCRIPTION
## Summary

- expands issue forms for bugs, crashes, features, research, design-system, navigation, and backend/runtime work
- adds SECURITY, SUPPORT, CODEOWNERS, Dependabot, discussion routing, and issue/discussion wiki guidance
- updates the PR template and PR workflow so the required `pr` check can exist for docs/community metadata changes while skipping expensive build steps when appropriate

## Live GitHub setup already applied

- renamed/created the prefixed label taxonomy
- created starter Discussions #27-#31
- cleaned up existing maintainer-authored issues and created architecture/automation follow-ups #32-#38
- enabled delete-branch-on-merge and squash/rebase merges while disabling merge commits
- added an active ruleset preventing deletion and force-pushes on `nightly`, `beta`, and `stable`

## Notes

- Full required-PR/check branch enforcement is not active yet because GitHub rejected safe bypasses for the Actions app on this personal repository; enforcing it directly would risk breaking release/appcast bot pushes.
- GitHub Projects setup is tracked in #37 because the current token lacks project scope.
- CodeQL tuning remains out of scope and tracked in #24.

## Validation

- [x] YAML parse for issue templates, Dependabot, and workflows
- [x] `git diff --check`
- [x] `./scripts/ci-validate.sh`
- [x] `./scripts/test-release-scripts.sh`
