### PR TITLE
docs: polish public contributor docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-.
+reported to the maintainer through the contact links on
+[tdeverx's GitHub profile](https://github.com/tdeverx). If the behavior also
+violates GitHub's platform rules, use
+[GitHub's abuse reporting flow](https://github.com/contact/report-abuse).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/README.md
+++ b/README.md
@@ -55,7 +55,21 @@ changes can be reviewed with code changes:
 - Start: [Features](https://github.com/tdeverx/contained-app/wiki/Features), [Installation](https://github.com/tdeverx/contained-app/wiki/Installation), [Keyboard Shortcuts](https://github.com/tdeverx/contained-app/wiki/Keyboard-Shortcuts), [Troubleshooting](https://github.com/tdeverx/contained-app/wiki/Troubleshooting)
 - Workflows: [Creation Workflow](https://github.com/tdeverx/contained-app/wiki/Creation-Workflow), [Run / Edit Form](https://github.com/tdeverx/contained-app/wiki/Run-Edit-Form), [Compose Import](https://github.com/tdeverx/contained-app/wiki/Compose-Import), [Command Palette](https://github.com/tdeverx/contained-app/wiki/Command-Palette), [Updates](https://github.com/tdeverx/contained-app/wiki/Updates)
 - Feature areas: [Containers](https://github.com/tdeverx/contained-app/wiki/Features-Containers), [Images](https://github.com/tdeverx/contained-app/wiki/Features-Images), [Resources](https://github.com/tdeverx/contained-app/wiki/Features-Resources), [System & Settings](https://github.com/tdeverx/contained-app/wiki/System-Settings)
-- Maintainers: [Architecture](https://github.com/tdeverx/contained-app/wiki/Architecture), [Design System](https://github.com/tdeverx/contained-app/wiki/Design-System), [Release Runbook](https://github.com/tdeverx/contained-app/wiki/Release), [Contributing](https://github.com/tdeverx/contained-app/wiki/Contributing)
+- Maintainers: [Architecture](https://github.com/tdeverx/contained-app/wiki/Architecture), [Design System](https://github.com/tdeverx/contained-app/wiki/Design-System), [Release Runbook](https://github.com/tdeverx/contained-app/wiki/Release), [Contributing](https://github.com/tdeverx/contained-app/wiki/Contributing), [Issues and Discussions](https://github.com/tdeverx/contained-app/wiki/Issues-and-Discussions)
+
+## Contributing And Support
+
+Start with the [wiki](https://github.com/tdeverx/contained-app/wiki) and
+[Troubleshooting](https://github.com/tdeverx/contained-app/wiki/Troubleshooting).
+Use [Discussions Q&A](https://github.com/tdeverx/contained-app/discussions/categories/q-a)
+for setup help and questions, and
+[open an issue](https://github.com/tdeverx/contained-app/issues/new/choose) for
+actionable bugs, crashes, regressions, or tracked feature work.
+
+Please read the [contributing guide](https://github.com/tdeverx/contained-app/wiki/Contributing)
+before opening a larger PR. Do not post vulnerabilities publicly; use
+[private vulnerability reporting](https://github.com/tdeverx/contained-app/security/advisories/new)
+instead.
 
 ## Architecture
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@ channels exist.
 
 ## Reporting A Vulnerability
 
-Please do not open a public issue for a vulnerability. Email the maintainer or
-use GitHub's private vulnerability reporting when it is available for this
-repository.
+Please do not open a public issue for a vulnerability. Use
+[GitHub private vulnerability reporting](https://github.com/tdeverx/contained-app/security/advisories/new)
+so details stay private while a fix is prepared.
 
 Include:
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -11,16 +11,19 @@ place that fits what you need.
 
 ## Where To Go
 
-- Use Discussions Q&A for setup help, "how do I..." questions, and unclear
-  behavior.
-- Use Ideas for early feature thoughts that are not ready to become tracked
-  work.
-- Use the Development and architecture starter thread in General for package,
-  backend, release-process, and automation design.
-- Use Issues for actionable bugs, crashes, regressions, accepted feature work,
-  architecture tasks, and implementation checklists.
-- Use private security reporting for vulnerabilities. Do not post security
-  details publicly.
+- Use [Discussions Q&A](https://github.com/tdeverx/contained-app/discussions/categories/q-a)
+  for setup help, "how do I..." questions, and unclear behavior.
+- Use [Ideas](https://github.com/tdeverx/contained-app/discussions/categories/ideas)
+  for early feature thoughts that are not ready to become tracked work.
+- Use the
+  [Development and architecture discussion](https://github.com/tdeverx/contained-app/discussions/30)
+  for package, backend, release-process, and automation design.
+- Use [Issues](https://github.com/tdeverx/contained-app/issues/new/choose) for
+  actionable bugs, crashes, regressions, accepted feature work, architecture
+  tasks, and implementation checklists.
+- Use
+  [private vulnerability reporting](https://github.com/tdeverx/contained-app/security/advisories/new)
+  for vulnerabilities. Do not post security details publicly.
 
 If you are unsure, start in Discussions. Maintainers can turn a discussion into
 an issue when it becomes a concrete task.


### PR DESCRIPTION
## Summary

- Add README links for support, issues/discussions, contributing, and private vulnerability reporting.
- Make SUPPORT routing links direct and clickable.
- Point SECURITY.md to GitHub private vulnerability reporting.
- Fill the missing Code of Conduct enforcement contact guidance.

## Linked Issue

- No linked issue because this is a small public-docs polish pass after the GitHub setup merge.
- [x] This PR links an issue, or explains why one is not needed

## Change Type

- [ ] App/UI behavior
- [ ] Core/runtime logic
- [ ] Release, workflow, or script behavior
- [x] Docs, issue templates, or repository metadata only

## Validation

- [x] `git diff --check`
- [x] `./scripts/ci-validate.sh`
- [ ] `swift build`
- [ ] `swift test`
- [ ] UI/app changes smoke-tested with `./scripts/bundle.sh debug`
- [ ] Release/script changes covered by `./scripts/test-release-scripts.sh` and relevant validators

## Release Notes And Docs

- [x] Added or updated a release/change note, or applied the `no-release-note` label for docs/meta-only work
- [x] Updated `docs/wiki` for user-facing behavior or workflow changes, or this PR does not need docs
- [x] Synced `Sources/Contained/Resources/CHANGELOG.md` when `CHANGELOG.md` changed (`./scripts/sync-changelog-resource.sh --check` passes)

## Update Safety

- [x] Build numbers still come only from `scripts/version-info.sh`
- [x] Nightly can still receive promoted Beta/Stable appcast items
- [x] Generated appcast commits still use `[skip ci]` and do not trigger release loops
- [ ] Bundle/appcast changes were validated with `scripts/validate-bundle.sh` and `scripts/validate-appcast.sh`

## Notes For Reviewers

- Docs-only change; no app behavior changed.