### PR TITLE
Fix packaged SwiftPM resource bundles

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,1 @@
+- Fixed Add, Run, and Edit crashing in packaged builds when ContainedCore localization resources were missing.

--- a/Documentation/Release/Release.md
+++ b/Documentation/Release/Release.md
@@ -73,7 +73,7 @@ VERSION="$VERSION" BUILD="$BUILD" ./Scripts/package.sh smoke Contained.app
 CHANNEL="$CHANNEL" ./Scripts/appcast.sh validate appcast.xml
 ```
 
-`Scripts/check.sh generated` catches tracked files rewritten by build/generation steps. `Scripts/package.sh smoke` checks the bundle executable, Info.plist version/build values, bundled changelog, Sparkle.framework, and code signature. `Scripts/appcast.sh validate` checks XML structure, numeric Sparkle build numbers, short versions, enclosure URLs, release notes, and channel shape; the nightly channel intentionally allows Stable/Beta/Nightly items because it is the superset feed.
+`Scripts/check.sh generated` catches tracked files rewritten by build/generation steps. `Scripts/package.sh smoke` checks the bundle executable, Info.plist version/build values, required SwiftPM resource bundles, bundled changelog, Sparkle.framework, and code signature. `Scripts/appcast.sh validate` checks XML structure, numeric Sparkle build numbers, short versions, enclosure URLs, release notes, and channel shape; the nightly channel intentionally allows Stable/Beta/Nightly items because it is the superset feed.
 
 ## One-time setup
 

--- a/Packages/ContainedCore/Sources/ContainedCore/Localization/CoreLocalization.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Localization/CoreLocalization.swift
@@ -1,7 +1,24 @@
 import Foundation
 
+private final class CoreLocalizationBundleToken: NSObject {}
+
 public extension Core {
     enum Localization {
+        private static let resourceBundle: Bundle? = {
+            let bundleName = "ContainedCore_ContainedCore.bundle"
+            let hosts = [Bundle.main, Bundle(for: CoreLocalizationBundleToken.self)]
+                + Bundle.allBundles
+                + Bundle.allFrameworks
+            let candidates: [URL?] = hosts.flatMap { host -> [URL?] in
+                [
+                    host.resourceURL?.appendingPathComponent(bundleName),
+                    host.bundleURL.appendingPathComponent(bundleName),
+                    host.bundleURL.deletingLastPathComponent().appendingPathComponent(bundleName),
+                ]
+            }
+            return candidates.compactMap { $0 }.lazy.compactMap(Bundle.init(url:)).first
+        }()
+
         public struct Entry: Sendable, Hashable {
             public var key: String
             public var defaultValue: String
@@ -22,7 +39,8 @@ public extension Core {
                                   resolver: Resolver? = nil) -> String {
             let entry = Entry(key: key, defaultValue: defaultValue, table: table)
             if let resolved = resolver?(entry) { return resolved }
-            let localized = Bundle.module.localizedString(forKey: key, value: defaultValue, table: table)
+            guard let resourceBundle else { return defaultValue }
+            let localized = resourceBundle.localizedString(forKey: key, value: defaultValue, table: table)
             return localized == key ? defaultValue : localized
         }
     }

--- a/Scripts/package.sh
+++ b/Scripts/package.sh
@@ -11,6 +11,12 @@ fail() {
   exit 1
 }
 
+required_resource_bundles=(
+  "Contained_ContainedApp.bundle"
+  "ContainedCore_ContainedCore.bundle"
+  "SwiftTerm_SwiftTerm.bundle"
+)
+
 usage() {
   cat >&2 <<'USAGE'
 Usage:
@@ -171,12 +177,10 @@ build_app() {
     install_name_tool -add_rpath "@executable_path/../Frameworks" "$app/Contents/MacOS/Contained" 2>/dev/null || true
   fi
 
-  for bundle_name in Contained_ContainedApp.bundle Contained_Contained.bundle; do
+  for bundle_name in "${required_resource_bundles[@]}"; do
     local bundle_res="$build_products/$bundle_name"
-    if [ -d "$bundle_res" ]; then
-      cp -R "$bundle_res" "$app/Contents/Resources/" || true
-      break
-    fi
+    [ -d "$bundle_res" ] || fail "Required SwiftPM resource bundle '$bundle_name' was not built"
+    cp -R "$bundle_res" "$app/Contents/Resources/"
   done
 
   echo "▸ Generating bundled release notes..."
@@ -225,15 +229,13 @@ smoke_bundle() {
   [ -f "$plist" ] || fail "Info.plist is missing"
   [ -x "$binary" ] || fail "Executable '$binary' is missing or not executable"
 
-  local resource_changelog=""
-  for bundle_name in Contained_ContainedApp.bundle Contained_Contained.bundle; do
-    local candidate="$app/Contents/Resources/$bundle_name/CHANGELOG.md"
-    if [ -f "$candidate" ]; then
-      resource_changelog="$candidate"
-      break
-    fi
+  for bundle_name in "${required_resource_bundles[@]}"; do
+    [ -d "$app/Contents/Resources/$bundle_name" ] \
+      || fail "Required SwiftPM resource bundle '$bundle_name' is missing"
   done
-  [ -n "$resource_changelog" ] || fail "Bundled CHANGELOG.md resource is missing"
+
+  local resource_changelog="$app/Contents/Resources/Contained_ContainedApp.bundle/CHANGELOG.md"
+  [ -f "$resource_changelog" ] || fail "Bundled CHANGELOG.md resource is missing"
   [ -s "$current_release_notes" ] || fail "CurrentReleaseNotes.md resource is missing or empty"
   [ -d "$sparkle_framework" ] || fail "Sparkle.framework is missing from the bundle"
 


### PR DESCRIPTION
## What changed

- package every required SwiftPM resource bundle in `Contents/Resources`
- resolve ContainedCore localization resources from packaged-app and SwiftPM test layouts without a fatal `Bundle.module` lookup
- make package smoke validation reject apps missing ContainedApp, ContainedCore, or SwiftTerm resources
- document the expanded release validation and add a current release note

## Root cause

The manual SwiftPM app assembly copied only the ContainedApp bundle. Opening the shared Add/Run/Edit form requested a localized ContainedCore field tip, whose generated `Bundle.module` accessor could not find `ContainedCore_ContainedCore.bundle` and terminated the process.

## Validation

- `swift test --package-path Packages/ContainedCore` (106 tests)
- `swift test --filter UpdaterControllerTests` (17 tests)
- `./Scripts/check.sh repo`
- `./Scripts/check.sh release`
- `./Scripts/package.sh app debug`
- `./Scripts/package.sh smoke Contained.app`
- `./Scripts/check.sh generated`
- `git diff --check`
