### PR TITLE
Integrate pending Dependabot updates

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload native test results
         if: always() && steps.changes.outputs.material == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-test-results
           path: Contained.xcresult

--- a/Contained.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Contained.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a8f5dc6e00a472c3eeb2a119470a8953cf7da94303a7c59e5de23a28bb553f37",
+  "originHash" : "feba240e0a8492e221980f8da68f347f9b4e740ca2f3f3621ae03d66509202de",
   "pins" : [
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "79bc9e872948e47877e76f194cb0c8e0412b0b90",
+        "version" : "2.9.5"
       }
     },
     {


### PR DESCRIPTION
## What changed

- update `actions/upload-artifact` from v4 to v7 (supersedes #55)
- update Sparkle from 2.9.4 to 2.9.5 (supersedes #56)
- keep the root and Xcode workspace SwiftPM pins synchronized

## Why

Sparkle 2.9.5 contains additional hardening for delta patch destination symlinks. Upload-artifact v7 uses the current Node 24 action runtime. Combining the updates fixes the stale standalone Sparkle PR, which changed only the root lockfile and failed repository parity validation.

## Validation

- `./Scripts/check.sh repo`
- `./Scripts/check.sh release`
- `swift build --arch arm64 --product Contained`
- `swift test` (119 tests)
- `git diff --check`
