### PR TITLE
Preserve immutable release artifacts

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -109,14 +109,17 @@ jobs:
         run: |
           set -euo pipefail
           tag="v${VERSION}"
+          asset="Contained-${VERSION}.dmg"
           if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" updates/*.dmg --clobber
-            gh release edit "$tag" \
-              --prerelease --title "Beta (${VERSION})" \
-              --notes-file updates/github-release-notes.md
+            target="$(gh release view "$tag" --json targetCommitish --jq .targetCommitish)"
+            [ "$target" = "$GITHUB_SHA" ] || { echo "Release $tag belongs to $target, not $GITHUB_SHA" >&2; exit 1; }
+            gh release download "$tag" --pattern "$asset" --dir updates --clobber
+            gh release verify "$tag"
+            gh release verify-asset "$tag" "updates/$asset"
           else
-            gh release create "$tag" updates/*.dmg \
-              --prerelease --title "Beta (${VERSION})" \
+            gh release create "$tag" "updates/$asset" \
+              --target "$GITHUB_SHA" --prerelease --latest=false \
+              --title "Beta (${VERSION})" \
               --notes-file updates/github-release-notes.md
           fi
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,9 @@
 name: Nightly
 
-# Builds the latest `nightly` branch, ad-hoc signs, packages a DMG, and refreshes the rolling
-# `nightly-latest` release. The Sparkle feed (appcast.xml at this branch's repo root) is then
-# regenerated for the new DMG and committed back to `nightly`. Promoted beta/stable items are kept
-# in this feed too, so Nightly users can receive those builds without changing channels.
+# Builds the latest `nightly` branch, ad-hoc signs, packages a DMG, and publishes an immutable
+# versioned pre-release. The Sparkle feed (appcast.xml at this branch's repo root) is then regenerated
+# for the new DMG and committed back to `nightly`. Promoted beta/stable items are kept in this feed
+# too, so Nightly users can receive those builds without changing channels.
 #
 # No Apple Developer ID / notarization (no paid account). First launch of an unsigned build needs
 # right-click ▸ Open. Only secret: SPARKLE_ED_PRIVATE_KEY (DMG still ships without it).
@@ -92,13 +92,23 @@ jobs:
             echo
             echo "⚠️ Unsigned build — first launch: right-click the app ▸ **Open** (or \`xattr -dr com.apple.quarantine /Applications/Contained.app\`)."
           } > updates/github-release-notes.md
-      - name: Publish rolling nightly-latest release
+      - name: Publish immutable nightly release
         run: |
           set -euo pipefail
-          gh release delete nightly-latest --yes --cleanup-tag || true
-          gh release create nightly-latest updates/*.dmg \
-            --prerelease --title "Nightly (${VERSION})" \
-            --notes-file updates/github-release-notes.md
+          tag="v${VERSION}"
+          asset="Contained-${VERSION}.dmg"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            target="$(gh release view "$tag" --json targetCommitish --jq .targetCommitish)"
+            [ "$target" = "$GITHUB_SHA" ] || { echo "Release $tag belongs to $target, not $GITHUB_SHA" >&2; exit 1; }
+            gh release download "$tag" --pattern "$asset" --dir updates --clobber
+            gh release verify "$tag"
+            gh release verify-asset "$tag" "updates/$asset"
+          else
+            gh release create "$tag" "updates/$asset" \
+              --target "$GITHUB_SHA" --prerelease --latest=false \
+              --title "Nightly (${VERSION})" \
+              --notes-file updates/github-release-notes.md
+          fi
 
       - name: Update Sparkle feed (nightly branch appcast.xml)
         if: env.SPARKLE_ED_PRIVATE_KEY != ''
@@ -110,7 +120,7 @@ jobs:
           BIN=".build/artifacts/sparkle/Sparkle/bin"
           [ -x "$BIN/generate_appcast" ] || BIN="$(dirname "$(find .build -type f -name generate_appcast | head -1)")"
           ED_KEY_FILE="$KEYFILE" \
-            DOWNLOAD_PREFIX="https://github.com/tdeverx/contained-app/releases/download/nightly-latest/" \
+            DOWNLOAD_PREFIX="https://github.com/tdeverx/contained-app/releases/download/v${VERSION}/" \
             ./Scripts/appcast.sh generate "$BIN" updates
           [ -s "$PREVIOUS_APPCAST" ] && ./Scripts/appcast.sh promote --non-nightly-only "$PREVIOUS_APPCAST" appcast.xml
           CHANNEL=nightly ./Scripts/appcast.sh validate appcast.xml

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -110,13 +110,16 @@ jobs:
         run: |
           set -euo pipefail
           tag="v${VERSION}"
+          asset="Contained-${VERSION}.dmg"
           if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" updates/*.dmg --clobber
-            gh release edit "$tag" \
-              --title "Contained ${VERSION}" \
-              --notes-file updates/github-release-notes.md
+            target="$(gh release view "$tag" --json targetCommitish --jq .targetCommitish)"
+            [ "$target" = "$GITHUB_SHA" ] || { echo "Release $tag belongs to $target, not $GITHUB_SHA" >&2; exit 1; }
+            gh release download "$tag" --pattern "$asset" --dir updates --clobber
+            gh release verify "$tag"
+            gh release verify-asset "$tag" "updates/$asset"
           else
-            gh release create "$tag" updates/*.dmg \
+            gh release create "$tag" "updates/$asset" \
+              --target "$GITHUB_SHA" \
               --title "Contained ${VERSION}" \
               --notes-file updates/github-release-notes.md
           fi

--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Nightly builds now use permanent versioned GitHub releases, preserving older builds for rollback and keeping Sparkle enclosure URLs immutable.

--- a/Documentation/Release/Release.md
+++ b/Documentation/Release/Release.md
@@ -97,9 +97,11 @@ Then:
 
 ## Nightly (CI)
 
-`.github/workflows/nightly.yml` builds the latest green `nightly` on every push (newest commit wins via `concurrency: cancel-in-progress`), ad-hoc signs, refreshes the rolling **nightly** pre-release with the new DMG, regenerates the nightly appcast item, preserves promoted beta/stable items already in the feed, and commits root `appcast.xml` to the `nightly` branch. It skips appcast signing when `SPARKLE_ED_PRIVATE_KEY` is absent.
+`.github/workflows/nightly.yml` builds the latest green `nightly` on every push (newest commit wins via `concurrency: cancel-in-progress`), ad-hoc signs, publishes a versioned **nightly** pre-release with the new DMG, regenerates the nightly appcast item with that permanent release URL, preserves promoted beta/stable items already in the feed, and commits root `appcast.xml` to the `nightly` branch. It skips appcast signing when `SPARKLE_ED_PRIVATE_KEY` is absent. Historical nightly releases remain available for manual rollback and regression testing; Sparkle advertises only the newest nightly item.
 
-`.github/workflows/beta.yml` and `.github/workflows/stable.yml` build promoted branches, retain the build number for the matching nightly commit when available, write their own branch appcast, and merge the promoted appcast item into the nightly feed. They upsert GitHub release assets on reruns so a retry refreshes the same tag instead of failing on an existing release. All workflows ask `Scripts/package.sh version` for the build number.
+`.github/workflows/beta.yml` and `.github/workflows/stable.yml` build promoted branches, retain the build number for the matching nightly commit when available, write their own branch appcast, and merge the promoted appcast item into the nightly feed. Published release tags and assets are immutable. On a workflow retry, the existing asset is downloaded and verified before appcast generation instead of being replaced. All workflows ask `Scripts/package.sh version` for the build number.
+
+GitHub release immutability must remain enabled for the repository. GitHub CLI creates a draft internally while uploading assets and publishes only after the upload succeeds; publication locks the tag and assets and creates the release attestation used by workflow retries.
 
 After appcast generation, workflows validate the branch feed before committing it. Beta and Stable workflows validate the promoted nightly feed inside the scratch nightly worktree before pushing the appcast-only `[skip ci]` commit.
 


### PR DESCRIPTION
## What changed

- publish every nightly under its versioned prerelease tag instead of replacing `nightly-latest`
- point Sparkle at the permanent versioned asset URL
- stop beta and stable reruns from clobbering published assets
- download and verify an existing immutable asset on safe workflow retries
- document retained nightlies as manual rollback and regression artifacts

## Why

The rolling nightly release deleted the previous rollback artifact and reused the same Sparkle enclosure URL for different bytes. GitHub recommends immutable releases, and Sparkle appcasts are designed to reference the published update enclosure directly.

## Validation

- `./Scripts/check.sh repo`
- `./Scripts/check.sh release`
- `swift test --filter UpdaterControllerTests`
- `git diff --check`
