### PR TITLE
Refactor menu bar as runtime center

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,3 @@
+### Changed
+
+- The menu-bar extra is now a compact runtime center with a stable sheet-material backdrop, shared System-panel cards, per-runtime status and controls, resource metrics, and focused quick actions.

--- a/Documentation/App/System-Settings.md
+++ b/Documentation/App/System-Settings.md
@@ -19,6 +19,15 @@ does not depend on Docker Desktop. Privileged kernel or DNS operations may
 trigger prompts handled by the CLI or macOS. Contained does not ask for or store
 administrator credentials.
 
+## Menu-bar runtime center
+
+The optional menu-bar extra is the compact companion to System. It shows one
+card per detected runtime with reachability, CLI version, running and stopped
+container counts, image count, and capability-scoped start, stop, restart, or
+retry controls. The card's System action opens the full management surface.
+Run, Activity, and update checks remain available as focused quick actions;
+creation, navigation, settings, and support workflows stay in the main app.
+
 ## Settings tabs
 
 Settings tabs use native grouped SwiftUI forms inside the shared Settings panel.

--- a/Packages/ContainedUI/Sources/ContainedUI/Tokens/UI.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Tokens/UI.swift
@@ -181,9 +181,10 @@ enum Tokens {
     }
 
     public enum MenuBar {
-        public static let width: CGFloat = 340
+        public static let width: CGFloat = 420
         public static let titleWidth: CGFloat = 78
         public static let padding: CGFloat = 14
+        public static let runtimeListMaxHeight: CGFloat = 420
     }
 
     /// The app toolbar band — custom (non-native) controls sized to macOS 26 Liquid Glass toolbar
@@ -471,6 +472,7 @@ public extension UI.MenuBar {
     enum Size {
         public static let width = UI.Tokens.MenuBar.width
         public static let titleWidth = UI.Tokens.MenuBar.titleWidth
+        public static let runtimeListMaxHeight = UI.Tokens.MenuBar.runtimeListMaxHeight
     }
 
     /// Menu-bar padding mirrors the compact popover inset.

--- a/Sources/ContainedApp/App/AppModel.swift
+++ b/Sources/ContainedApp/App/AppModel.swift
@@ -1155,22 +1155,22 @@ final class AppModel {
     }
 
     /// Start the container system service and optionally restore Always-policy containers.
-    func startService() async {
-        if await runServiceLifecycle([.start]) {
+    func startService(runtimeKind: Core.Runtime.Kind? = nil) async {
+        if await runServiceLifecycle([.start], runtimeKind: runtimeKind) {
             logger.record("Started container service", category: .system)
         }
     }
 
     /// Stop the container system service, then re-bootstrap.
-    func stopService() async {
-        if await runServiceLifecycle([.stop]) {
+    func stopService(runtimeKind: Core.Runtime.Kind? = nil) async {
+        if await runServiceLifecycle([.stop], runtimeKind: runtimeKind) {
             logger.record("Stopped container service", category: .system, severity: .warning)
         }
     }
 
     /// Stop then start the container system service, optionally restoring Always-policy containers.
-    func restartService() async {
-        if await runServiceLifecycle([.stop, .start]) {
+    func restartService(runtimeKind: Core.Runtime.Kind? = nil) async {
+        if await runServiceLifecycle([.stop, .start], runtimeKind: runtimeKind) {
             logger.record("Restarted container service", category: .system, severity: .warning)
         }
     }
@@ -1180,7 +1180,8 @@ final class AppModel {
     @discardableResult
     private func runServiceLifecycle(_ actions: [Core.Runtime.SystemAction],
                                      runtimeKind requestedKind: Core.Runtime.Kind? = nil) async -> Bool {
-        guard let kind = requestedKind ?? serviceControlRuntimeKind, serviceControlRuntimeAvailable else {
+        guard let kind = requestedKind ?? serviceControlRuntimeKind,
+              client?.supportsRuntime(kind, capability: .serviceControl) == true else {
             flash(AppText.string("runtime.service.unavailable",
                                  defaultValue: "Service controls are not available for the current runtime. Start the runtime provider externally, then retry."))
             return false

--- a/Sources/ContainedApp/Navigation/MenuBar/MenuBarContent.swift
+++ b/Sources/ContainedApp/Navigation/MenuBar/MenuBarContent.swift
@@ -2,33 +2,19 @@ import SwiftUI
 import ContainedCore
 import ContainedUI
 
-/// The menu shown by the menu-bar extra: a compact command surface with service status, running
-/// containers, live resource counts, and the same creation / navigation affordances as the app menu.
+/// A compact runtime center for the menu-bar extra. Deeper creation, navigation, settings, and
+/// support workflows stay in the main app; this surface is intentionally status-and-action focused.
 struct MenuBarContent: View {
-    @Environment(\.openURL) private var openURL
     @Environment(AppModel.self) private var app
     @Environment(UIState.self) private var ui
 
-    private var store: ContainersStore { app.containers }
-    private var stopped: [Core.Container.Snapshot] { store.snapshots.filter { $0.state != .running } }
-    private var unreadActivityCount: Int { app.historyStore.activitySummary.unreadEvents }
-    private var statusRuntimeKind: Core.Runtime.Kind? {
-        app.serviceControlRuntimeKind ?? app.firstRuntimeKind(supporting: .systemStatus, readyOnly: false)
+    private var runtimeDescriptors: [Core.Runtime.Descriptor] {
+        let registered = app.registeredRuntimeDescriptors
+        return registered.isEmpty ? app.supportedRuntimeDescriptors : registered
     }
 
-    private var cliLabel: String {
-        switch app.bootstrap {
-        case .ready:
-            return statusRuntimeKind.flatMap { app.runtimeVersion(for: $0) }.map { "CLI v\($0)" } ?? "CLI ready"
-        case .checking:
-            return "Checking CLI"
-        case .cliMissing:
-            return "CLI missing"
-        case .unsupported(let version):
-            return "CLI v\(version) unsupported"
-        case .serviceStopped:
-            return "Service stopped"
-        }
+    private var unreadActivityCount: Int {
+        app.historyStore.activitySummary.unreadEvents
     }
 
     var body: some View {
@@ -37,171 +23,112 @@ struct MenuBarContent: View {
 
             Divider()
 
-            infoGrid
+            runtimeSection
 
             Divider()
 
-            actionStrip
+            quickActions
 
             Divider()
 
-            Menu("Service") {
-                statusItem
-                Divider()
-                if app.serviceControlRuntimeAvailable {
-                    if app.serviceHealthy {
-                        Button("Stop Service") { Task { await app.stopService() } }
-                    } else {
-                        Button("Start Service") { Task { await app.startService() } }
-                    }
-                    Button("Restart Service") { Task { await app.restartService() } }
-                } else {
-                    Button("Retry Runtime Connection") { Task { await app.retryBootstrap() } }
-                }
-            }
-
-            Menu("Containers") {
-                Menu("Running Containers") {
-                    if store.running.isEmpty {
-                        disabledPlaceholder("No running containers")
-                    } else {
-                        ForEach(store.running) { snapshot in
-                            Button(containerName(for: snapshot)) {
-                                Task { await store.stop(snapshot.scopedID) }
-                            }
-                        }
-                    }
-                }
-
-                Menu("Stopped Containers") {
-                    if stopped.isEmpty {
-                        disabledPlaceholder("No stopped containers")
-                    } else {
-                        ForEach(stopped) { snapshot in
-                            Button(containerName(for: snapshot)) {
-                                Task { await store.start(snapshot.scopedID) }
-                            }
-                        }
-                    }
-                }
-            }
-
-            Menu("Create") {
-                Button("Run Container…") { activate(); route(.runContainer) }
-                Button("Pull Image…") { activate(); route(.pullImage) }
-                    .disabled(!app.settings.hubSearchEnabled)
-                Button("Build Image…") { activate(); route(.build) }
-                    .disabled(!app.settings.imageBuildEnabled)
-                Divider()
-                Button("New Volume…") { activate(); route(.createVolume) }
-                Button("New Network…") { activate(); route(.createNetwork) }
-                Button("Import Compose…") { activate(); route(.importCompose) }
-                    .disabled(!app.settings.composeImportEnabled)
-            }
-
-            Menu("Navigate") {
-                Button("Containers") { activate(); navigate(to: .containers) }
-                Button("Images") { activate(); openSectionOrMorph(.images, morph: .updates) }
-                Button("Templates") { activate(); openSectionOrMorph(.templates, morph: .templates) }
-                Button("System") { activate(); openSectionOrMorph(.system, morph: .system) }
-                Button("Activity") { activate(); openSectionOrMorph(.activity, morph: .activity) }
-            }
-
-            Menu("Shortcuts") {
-                if app.settings.keyboardShortcutsEnabled {
-                    Button(ui.sidebarVisible ? "Hide Sidebar" : "Show Sidebar") { activate(); ui.setSidebarVisible(!ui.sidebarVisible) }
-                        .keyboardShortcut("s", modifiers: .command)
-                        .disabled(!app.settings.sidebarNavigationEnabled)
-                    Button("Search This Page") { activate(); ui.focusSearch() }
-                        .keyboardShortcut("f", modifiers: .command)
-                    Button("Settings") { activate(); openSettings(to: .appearance) }
-                        .keyboardShortcut(";", modifiers: .command)
-                    Button("Run Container") { activate(); route(.runContainer) }
-                        .keyboardShortcut("n", modifiers: .command)
-                    Button("Run Image Check") { Task { await app.runImageUpdateSweepNow() } }
-                        .keyboardShortcut("u", modifiers: .command)
-                    Button("Activity") { activate(); route(.activityHistory) }
-                        .keyboardShortcut("i", modifiers: .command)
-                } else {
-                    disabledPlaceholder("Enable keyboard shortcuts in Settings → Experimental")
-                }
-            }
-
-            Menu("Settings") {
-                Button("Open Contained") { activate() }
-                Divider()
-                ForEach(SettingsContent.SettingsPage.allCases) { page in
-                    Button(page.rawValue) { activate(); openSettings(to: page) }
-                }
-            }
-
-            Menu("Help") {
-                Button("Check for Updates…") {
-                    activate()
-                    app.updater.checkForUpdates()
-                }
-                Button("About Contained") { activate(); openSettings(to: .about) }
-                Button("Reveal CLI Binary in Finder") { activate(); revealCLIBinary() }
-                Divider()
-                Button("Release Notes") { activate(); openURL(Links.releasesURL) }
-                Button("Troubleshooting") { activate(); openURL(Links.troubleshootingURL) }
-                Button("Keyboard Shortcuts") { activate(); openURL(Links.shortcutsURL) }
-            }
-
-            Divider()
-
-            footerRow
+            footer
         }
         .padding(UI.MenuBar.Padding.all)
         .frame(width: UI.MenuBar.Size.width)
+        .background {
+            UI.Theme.BackgroundLayer(material: .sheet)
+        }
     }
 
-    @ViewBuilder
     private var header: some View {
-        VStack(alignment: .leading, spacing: UI.Toolbar.Spacing.searchIconGap) {
-            HStack(alignment: .firstTextBaseline) {
+        VStack(alignment: .leading, spacing: UI.Layout.Spacing.xs) {
+            HStack(spacing: UI.Layout.Spacing.s) {
                 Label("Contained", systemImage: app.serviceHealthy ? "shippingbox.fill" : "shippingbox")
-                    .designHeadlineLabelStyle()
+                    .designTitleLabelStyle()
                 Spacer(minLength: 0)
-                Text("\(store.running.count)")
-                    .designSecondaryMonospacedDigitHeadline()
+                UI.Badge.Status(text: runningSummary,
+                                tint: app.containers.running.isEmpty ? .secondary : .green)
             }
 
-            HStack(spacing: UI.Card.Padding.content) {
-                UI.State.InlineStatus(app.serviceLabel,
-                                   systemImage: app.serviceHealthy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill",
-                                   tone: app.serviceHealthy ? .success : .neutral)
-                UI.State.StatusText(app.settings.updateChannel.displayName,
-                                 style: .caption)
+            HStack(spacing: UI.Layout.Spacing.s) {
+                UI.State.InlineStatus(overallStatus,
+                                      systemImage: app.serviceHealthy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill",
+                                      tone: app.serviceHealthy ? .success : .warning)
+                UI.State.StatusText(app.settings.updateChannel.displayName, style: .caption)
                 Spacer(minLength: 0)
                 if unreadActivityCount > 0 {
                     UI.State.InlineStatus("\(unreadActivityCount) unread",
-                                       systemImage: "bell.badge")
+                                          systemImage: "bell.badge",
+                                          tone: .accent)
                 }
             }
         }
     }
 
+    private var runtimeSection: some View {
+        VStack(alignment: .leading, spacing: UI.Layout.Spacing.s) {
+            HStack {
+                Text("Runtimes")
+                    .designSectionLabelStyle()
+                Spacer(minLength: 0)
+                Text("\(runtimeDescriptors.count)")
+                    .designSecondaryMonospacedDigitCaption()
+            }
+
+            runtimeCards
+        }
+    }
+
     @ViewBuilder
-    private var infoGrid: some View {
-        LazyVStack(alignment: .leading, spacing: UI.Layout.Spacing.s) {
-            UI.List.CompactInfoRow("Containers", value: "\(store.running.count) running · \(stopped.count) stopped")
-            UI.List.CompactInfoRow("Resources", value: "\(app.images.count) images · \(app.volumes.count) volumes · \(app.networks.count) networks")
-            UI.List.CompactInfoRow("Bootstrap", value: cliLabel)
-            UI.List.CompactInfoRow("Activity", value: unreadActivityCount > 0 ? "\(unreadActivityCount) unread" : "All caught up")
+    private var runtimeCards: some View {
+        if runtimeDescriptors.count > 2 {
+            ScrollView {
+                runtimeCardStack
+            }
+            .scrollIndicators(.hidden)
+            .frame(height: UI.MenuBar.Size.runtimeListMaxHeight)
+        } else {
+            runtimeCardStack
         }
     }
 
-    private var actionStrip: some View {
+    private var runtimeCardStack: some View {
+        LazyVStack(spacing: UI.Layout.Spacing.s) {
+            ForEach(runtimeDescriptors, id: \.kind) { descriptor in
+                MenuBarRuntimeCard(descriptor: descriptor,
+                                   openSystem: openSystem)
+            }
+        }
+    }
+
+    private var quickActions: some View {
         HStack(spacing: UI.Layout.Spacing.s) {
-            miniAction("Open", systemImage: "app")
-            miniAction("Run", systemImage: "plus") { route(.runContainer) }
-            miniAction("Activity", systemImage: unreadActivityCount > 0 ? "bell.badge" : "bell") { route(.activityHistory) }
-            miniAction("Updates", systemImage: "arrow.triangle.2.circlepath") { app.updater.checkForUpdates() }
+            UI.Action.Group([
+                UI.Action.Item(systemName: "plus",
+                               title: "Run",
+                               help: "Run Container") {
+                    activate()
+                    ui.dispatch(.runContainer)
+                },
+                UI.Action.Item(systemName: unreadActivityCount > 0 ? "bell.badge" : "bell",
+                               title: "Activity",
+                               help: "Activity",
+                               tint: unreadActivityCount > 0 ? .accentColor : nil) {
+                    activate()
+                    ui.dispatch(.activityHistory)
+                },
+                UI.Action.Item(systemName: "arrow.triangle.2.circlepath",
+                               title: "Updates",
+                               help: "Check for Updates") {
+                    activate()
+                    app.updater.checkForUpdates()
+                }
+            ])
+            Spacer(minLength: 0)
         }
     }
 
-    private var footerRow: some View {
+    private var footer: some View {
         HStack(spacing: UI.Layout.Spacing.s) {
             Button("Open Contained") { activate() }
             Spacer(minLength: 0)
@@ -210,69 +137,29 @@ struct MenuBarContent: View {
         .buttonStyle(.borderless)
     }
 
-    @ViewBuilder
-    private func miniAction(_ title: String,
-                            systemImage: String,
-                            action: @escaping () -> Void = {}) -> some View {
-        Button(action: {
-            activate()
-            action()
-        }) {
-            Label(title, systemImage: systemImage)
+    private var runningSummary: String {
+        let count = app.containers.running.count
+        return "\(count) running"
+    }
+
+    private var overallStatus: String {
+        if runtimeDescriptors.isEmpty { return "No runtimes detected" }
+        let ready = runtimeDescriptors.filter { app.runtimeIsReady($0.kind) }.count
+        if ready == runtimeDescriptors.count { return "All runtimes available" }
+        if ready > 0 { return "\(ready) of \(runtimeDescriptors.count) available" }
+        return "Runtimes unavailable"
+    }
+
+    private func openSystem() {
+        activate()
+        if app.settings.usesPanelNavigation {
+            ui.toggleMorph(.system)
+        } else {
+            ui.navigate(to: .system)
         }
-        .buttonStyle(.borderless)
     }
 
-    @ViewBuilder
-    private func disabledPlaceholder(_ text: String) -> some View {
-        Button(text) { }
-            .disabled(true)
-    }
-
-    @ViewBuilder
-    private var statusItem: some View {
-        UI.State.InlineStatus(app.serviceLabel,
-                           systemImage: app.serviceHealthy ? "checkmark.circle.fill" : "exclamationmark.triangle.fill",
-                           tone: app.serviceHealthy ? .success : .neutral)
-    }
-
-    /// Bring the main window to the front.
     private func activate() {
         Platform.activateMainWindow()
-    }
-
-    private func containerName(for snapshot: Core.Container.Snapshot) -> String {
-        app.containerStyle(for: snapshot).displayName(fallback: snapshot.id)
-    }
-
-    private func navigate(to section: AppSection) {
-        ui.navigate(to: section)
-    }
-
-    private func route(_ action: PendingAction) {
-        ui.dispatch(action)
-    }
-
-    private func openSectionOrMorph(_ section: AppSection, morph: UIState.ToolbarMorph) {
-        if app.settings.usesPanelNavigation {
-            ui.toggleMorph(morph)
-        } else {
-            ui.navigate(to: section)
-        }
-    }
-
-    private func openSettings(to page: SettingsContent.SettingsPage) {
-        ui.settingsPage = page
-        if app.settings.usesPanelNavigation {
-            ui.openSettings(to: page)
-        } else {
-            ui.navigate(to: .settings)
-        }
-    }
-
-    /// Reveal the resolved `container` binary in Finder (honoring the CLI-path override).
-    private func revealCLIBinary() {
-        guard let url = app.runtimeCLIURL(for: .appleContainer) else { return }
-        Platform.revealInFinder(url)
     }
 }

--- a/Sources/ContainedApp/Navigation/MenuBar/MenuBarRuntimeCard.swift
+++ b/Sources/ContainedApp/Navigation/MenuBar/MenuBarRuntimeCard.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+import ContainedCore
+import ContainedUI
+
+/// Menu-bar density for the runtime summary used by the full System panel.
+struct MenuBarRuntimeCard: View {
+    @Environment(AppModel.self) private var app
+
+    let descriptor: Core.Runtime.Descriptor
+    let openSystem: () -> Void
+
+    @State private var working = false
+
+    private var readiness: Core.RuntimeReadiness.State? {
+        app.runtimeReadiness[descriptor.kind]?.state
+    }
+
+    private var snapshots: [Core.Container.Snapshot] {
+        app.containers.snapshots.filter { $0.runtimeKind == descriptor.kind }
+    }
+
+    private var runningCount: Int {
+        snapshots.filter { $0.state == .running }.count
+    }
+
+    private var stoppedCount: Int {
+        snapshots.count - runningCount
+    }
+
+    private var imageCount: Int {
+        app.images.filter { $0.runtimeKind == descriptor.kind }.count
+    }
+
+    var body: some View {
+        UI.Surface.Content(alignment: .leading, padding: UI.Card.Padding.content) {
+            VStack(alignment: .leading, spacing: UI.Layout.Spacing.m) {
+                header
+                metrics
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: UI.Layout.Spacing.s) {
+            UI.Badge.Dot(color: statusTint, size: UI.Control.Size.serviceDot)
+
+            VStack(alignment: .leading, spacing: UI.Layout.Spacing.xxs) {
+                HStack(spacing: UI.Layout.Spacing.xs) {
+                    Text(descriptor.displayName)
+                        .designHeadlineLabelStyle()
+                    UI.Badge.Status(text: statusLabel, tint: statusTint)
+                }
+                Text(runtimeDetail)
+                    .designSecondaryMonospacedCaption()
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+
+            controls
+        }
+    }
+
+    private var metrics: some View {
+        HStack(spacing: UI.Layout.Spacing.s) {
+            UI.Control.MetricTile(label: "Running", value: "\(runningCount)")
+            UI.Control.MetricTile(label: "Stopped", value: "\(stoppedCount)")
+            UI.Control.MetricTile(label: "Images", value: "\(imageCount)")
+        }
+    }
+
+    private var controls: some View {
+        UI.Action.Group(controlActions)
+    }
+
+    private var controlActions: [UI.Action.Item] {
+        var actions: [UI.Action.Item] = []
+
+        if descriptor.supports(.serviceControl) {
+            actions.append(powerAction)
+            actions.append(UI.Action.Item(systemName: "arrow.clockwise",
+                                          help: AppText.restartService,
+                                          isEnabled: !working) {
+                run { await app.restartService(runtimeKind: descriptor.kind) }
+            })
+        } else if readiness != .ready {
+            actions.append(UI.Action.Item(systemName: "arrow.clockwise",
+                                          help: AppText.string("common.retry", defaultValue: "Retry"),
+                                          isEnabled: !working) {
+                run { await app.retryBootstrap() }
+            })
+        }
+
+        actions.append(UI.Action.Item(systemName: "arrow.up.forward.app",
+                                      help: "Open System",
+                                      isEnabled: !working,
+                                      action: openSystem))
+        return actions
+    }
+
+    private var powerAction: UI.Action.Item {
+        if readiness == .ready {
+            return UI.Action.Item(systemName: "stop.fill",
+                                  help: AppText.stopService,
+                                  role: .destructive,
+                                  isEnabled: !working) {
+                run { await app.stopService(runtimeKind: descriptor.kind) }
+            }
+        }
+
+        return UI.Action.Item(systemName: "play.fill",
+                              help: AppText.startService,
+                              isEnabled: !working) {
+            run { await app.startService(runtimeKind: descriptor.kind) }
+        }
+    }
+
+    private var statusLabel: String {
+        switch readiness {
+        case .ready: "Running"
+        case .endpointUnavailable: "Stopped"
+        case .unsupported: "Unsupported"
+        case .cliMissing: "Unavailable"
+        case nil: "Checking"
+        }
+    }
+
+    private var statusTint: Color {
+        switch readiness {
+        case .ready: .green
+        case .endpointUnavailable: .orange
+        case .unsupported: .red
+        case .cliMissing, nil: .secondary
+        }
+    }
+
+    private var runtimeDetail: String {
+        let executable = descriptor.executableName ?? descriptor.kind.rawValue
+        if let version = app.runtimeVersion(for: descriptor.kind) {
+            return "\(executable) \(version)"
+        }
+        return executable
+    }
+
+    private func run(_ action: @escaping () async -> Void) {
+        working = true
+        Task {
+            await action()
+            working = false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the legacy command-heavy menu with a compact per-runtime status center
- add capability-scoped runtime controls and shared metric surfaces
- retain a sheet-material substrate for nested Liquid Glass elements
- document the new menu-bar behavior and add its nightly release note

## Validation
- swift test (119 tests)
- ./Scripts/check.sh repo
- git diff --check
- xcodebuild -workspace Contained.xcworkspace -scheme Contained -configuration Debug build