### PR TITLE
Add container update and rebuild actions

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,3 @@
+### Added
+
+- Container cards now surface a dedicated Update action when their image tag has changed, while the context menu provides a safe Rebuild action at all times; both preserve local settings and the container's prior running or stopped state.

--- a/Documentation/Features/Containers.md
+++ b/Documentation/Features/Containers.md
@@ -24,7 +24,16 @@ owning runtime:
 - delete
 - refresh
 - edit
-- update image when an image update is available
+- rebuild from the image currently behind the container's tag
+- update when that tag has changed locally or a newer remote image is available
+
+Rebuild is always available from a container's context menu. When the app knows
+that the container's immutable image identity differs from the current tag—or a
+newer registry digest is available—the action is relabeled **Update Container**
+and an orange update button appears in the card footer. Updating pulls first only
+when needed, then recreates through the same rollback path as Edit → Save.
+Rebuild and Update preserve whether the container was running or stopped, while
+ordinary Start, Stop, and Restart remain non-destructive lifecycle operations.
 
 The app serializes refreshes around lifecycle actions so a user action and the
 background polling tick do not fight over inventory and stats streams. While the

--- a/Packages/ContainedCore/Sources/ContainedCore/Image/UpdateStatus.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Image/UpdateStatus.swift
@@ -9,6 +9,43 @@ enum UpdateState: String, Sendable, Codable, Equatable {
     case error
 }
 
+/// Whether a container's immutable image identity still matches the image currently behind its tag.
+enum ContainerUpdateState: String, Sendable, Codable, Equatable {
+    case unknown
+    case current
+    case updateAvailable
+    case updateReady
+
+    public var requiresUpdate: Bool {
+        self == .updateAvailable || self == .updateReady
+    }
+
+    public var needsPull: Bool { self == .updateAvailable }
+
+    /// Resolve remote availability before the local identity comparison. When another remote update
+    /// exists after a previous pull, applying should pull that newest image before recreating.
+    public static func resolve(containerIdentity: String?,
+                               localIdentities: [String],
+                               trackedStatus: Core.Image.UpdateStatus) -> Core.Image.ContainerUpdateState {
+        if trackedStatus.state == .updateAvailable { return .updateAvailable }
+        guard let containerIdentity,
+              !containerIdentity.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !localIdentities.isEmpty else {
+            return .unknown
+        }
+        let containerKey = normalizedContentIdentity(containerIdentity)
+        let matchesCurrentImage = localIdentities.contains {
+            normalizedContentIdentity($0) == containerKey
+        }
+        return matchesCurrentImage ? .current : .updateReady
+    }
+
+    private static func normalizedContentIdentity(_ value: String) -> String {
+        let key = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return key.hasPrefix("sha256:") ? String(key.dropFirst("sha256:".count)) : key
+    }
+}
+
 struct UpdateStatus: Sendable, Codable, Equatable {
     public var state: Core.Image.UpdateState
     public var localDigest: String?

--- a/Packages/ContainedCore/Sources/ContainedCore/Runtimes/Docker/Client/DockerModels.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Runtimes/Docker/Client/DockerModels.swift
@@ -26,6 +26,7 @@ enum DockerJSON {
 
 struct DockerContainerInspect: Decodable {
     var id: String
+    var imageID: String?
     var name: String?
     var config: Config
     var state: State?
@@ -37,6 +38,7 @@ struct DockerContainerInspect: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case id = "Id"
+        case imageID = "Image"
         case name = "Name"
         case config = "Config"
         case state = "State"
@@ -161,7 +163,12 @@ struct DockerContainerInspect: Decodable {
                           startedDate: parsedStartedDate()),
             configuration: .init(runtimeKind: Core.Runtime.Kind.docker,
                                  id: name.isEmpty ? shortID : name,
-                                 image: .init(reference: reference),
+                                 image: .init(
+                                    reference: reference,
+                                    descriptor: nilIfEmpty(imageID).map {
+                                        Core.Container.Descriptor(digest: $0, mediaType: nil, size: nil)
+                                    }
+                                 ),
                                  initProcess: .init(executable: command.first,
                                                     arguments: command,
                                                     environment: config.env ?? [],
@@ -564,7 +571,10 @@ private struct DockerContainerSnapshotPayload: Encodable {
         var stopSignal: String?
         var creationDate: Date?
 
-        struct Image: Encodable { var reference: String }
+        struct Image: Encodable {
+            var reference: String
+            var descriptor: Core.Container.Descriptor?
+        }
         struct InitProcess: Encodable {
             var executable: String?
             var arguments: [String]

--- a/Packages/ContainedCore/Sources/ContainedCore/Schema/ContainerDocumentTranslation.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Schema/ContainerDocumentTranslation.swift
@@ -148,7 +148,7 @@ public extension Core.Schema.Document {
                                            value: String(entry[entry.index(after: eq)...]))
         }
         request.labels = configuration.labels
-            .filter { !$0.key.hasPrefix("contained.") }
+            .filter { !$0.key.hasPrefix("contained.") || $0.key == "contained.stack" }
             .sorted { $0.key < $1.key }
             .map { Core.Container.KeyValue(key: $0.key, value: $0.value) }
         request.restart = Core.Container.RestartPolicy(label: configuration.labels["contained.restart"])

--- a/Packages/ContainedCore/Tests/ContainedCoreTests/DecodingTests.swift
+++ b/Packages/ContainedCore/Tests/ContainedCoreTests/DecodingTests.swift
@@ -141,6 +141,7 @@ struct DecodingTests {
         [
           {
             "Id": "0123456789abcdef",
+            "Image": "sha256:image-content-id",
             "Name": "/web",
             "Created": "2026-07-03T09:30:00Z",
             "Platform": "linux/arm64/v8",
@@ -195,6 +196,7 @@ struct DecodingTests {
         #expect(snapshot.scopedID == "docker::web")
         #expect(snapshot.state == .running)
         #expect(snapshot.image == "nginx:latest")
+        #expect(snapshot.configuration.image.descriptor?.digest == "sha256:image-content-id")
         #expect(snapshot.configuration.runtimeKind == .docker)
         #expect(snapshot.configuration.initProcess.arguments == ["nginx", "-g", "daemon off;"])
         #expect(snapshot.configuration.initProcess.environment == ["FOO=bar"])

--- a/Packages/ContainedCore/Tests/ContainedCoreTests/ImageWorkflowTests.swift
+++ b/Packages/ContainedCore/Tests/ContainedCoreTests/ImageWorkflowTests.swift
@@ -34,6 +34,34 @@ struct ImageWorkflowTests {
         #expect(failed.message == "boom")
     }
 
+    @Test func containerUpdateStateDistinguishesRemoteAndPulledUpdates() {
+        let current = Core.Image.UpdateStatus.resolved(localDigest: "sha256:current",
+                                                       remoteDigest: "sha256:current")
+        let available = Core.Image.UpdateStatus.resolved(localDigest: "sha256:current",
+                                                         remoteDigest: "sha256:new")
+
+        #expect(Core.Image.ContainerUpdateState.resolve(
+            containerIdentity: "sha256:current",
+            localIdentities: ["current"],
+            trackedStatus: current
+        ) == .current)
+        #expect(Core.Image.ContainerUpdateState.resolve(
+            containerIdentity: "sha256:current",
+            localIdentities: ["sha256:new"],
+            trackedStatus: current
+        ) == .updateReady)
+        #expect(Core.Image.ContainerUpdateState.resolve(
+            containerIdentity: "sha256:current",
+            localIdentities: ["sha256:current"],
+            trackedStatus: available
+        ) == .updateAvailable)
+        #expect(Core.Image.ContainerUpdateState.resolve(
+            containerIdentity: nil,
+            localIdentities: ["sha256:current"],
+            trackedStatus: current
+        ) == .unknown)
+    }
+
     @Test func localTagGroupingUsesDigest() throws {
         let json = """
         [

--- a/Sources/ContainedApp/App/AppModel+ImageUpdates.swift
+++ b/Sources/ContainedApp/App/AppModel+ImageUpdates.swift
@@ -50,6 +50,23 @@ extension AppModel {
             ?? Core.Image.UpdateStatus()
     }
 
+    /// Combine registry state with the immutable image identity captured when a container was
+    /// created. A successful pull makes the registry status current, but leaves the old container
+    /// pointing at its previous identity until it is recreated.
+    func containerImageUpdateState(for snapshot: Core.Container.Snapshot) -> Core.Image.ContainerUpdateState {
+        let referenceKey = imageUpdateKey(snapshot.image)
+        let localImage = images.first {
+            $0.runtimeKind == snapshot.runtimeKind && imageUpdateKey($0.reference) == referenceKey
+        }
+        let localIdentities = [localImage?.id, localImage?.digest]
+            .compactMap { $0 }
+        return Core.Image.ContainerUpdateState.resolve(
+            containerIdentity: snapshot.configuration.image.descriptor?.digest,
+            localIdentities: localIdentities,
+            trackedStatus: imageUpdateStatus(for: snapshot.image, runtimeKind: snapshot.runtimeKind)
+        )
+    }
+
     /// The normalized dictionary key for a reference, so `nginx` and `docker.io/library/nginx:latest`
     /// map to the same tracked status.
     func imageUpdateKey(_ reference: String) -> String {
@@ -192,6 +209,49 @@ extension AppModel {
             logger.record("Updated image", category: .image)
         }
         return ok
+    }
+
+    /// Recreate one container from the image currently behind its tag. If the registry check still
+    /// reports a newer remote image, pull it first. Local presentation, health, linked-volume paths,
+    /// rollback configuration, and the container's prior running/stopped state are preserved.
+    @discardableResult
+    func rebuildContainer(_ requestedSnapshot: Core.Container.Snapshot) async -> Bool {
+        guard let snapshot = containers.snapshots.first(where: {
+            $0.scopedID == requestedSnapshot.scopedID
+        }) else {
+            flash(AppText.recreateOriginalUnavailable)
+            return false
+        }
+
+        let updateState = containerImageUpdateState(for: snapshot)
+        if updateState.needsPull,
+           !(await pullImageUpdate(snapshot.image, runtimeKind: snapshot.runtimeKind)) {
+            return false
+        }
+
+        var spec = ContainerFormState(from: snapshot.configuration)
+        spec.personalization = containerStyle(for: snapshot)
+        spec.healthCheck = healthChecks.check(for: snapshot.scopedID) ?? Core.Container.HealthCheck()
+        spec.applyLinkedVolumePaths(database.linkedVolumePaths(for: snapshot.scopedID))
+
+        let shouldRemainStopped = snapshot.state != .running
+        guard let replacementID = await recreateContainer(originalID: snapshot.scopedID, spec: spec) else {
+            if shouldRemainStopped,
+               containers.recreateFailure?.recovery == .originalRestored {
+                await containers.stop(snapshot.scopedID)
+            }
+            return false
+        }
+
+        if shouldRemainStopped {
+            await containers.stop(snapshot.runtimeKind.scopedID(for: replacementID))
+        }
+        if updateState.requiresUpdate {
+            flash(AppText.updatedContainer(Format.shortImage(snapshot.image)))
+        } else {
+            flash(AppText.rebuiltContainer(containerStyle(for: snapshot).displayName(fallback: snapshot.id)))
+        }
+        return true
     }
 
     /// Background entry point (from `tick()`): run a silent sweep only when the throttle window has

--- a/Sources/ContainedApp/Features/Containers/Card/ContainerCard.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainerCard.swift
@@ -15,7 +15,7 @@ struct ContainerCard: View {
     /// without borrowing another metric's samples.
     var histories: [Core.Metrics.GraphMetric: UI.Chart.SampleBuffer] = [:]
     var isBusy: Bool
-    var hasImageUpdate: Bool = false
+    var imageUpdateState: Core.Image.ContainerUpdateState = .unknown
     var isExpanded: Bool = false
     var cornerRadiusOverride: CGFloat?
     /// Whether the expanded card's controls (footer buttons + close) are shown. The grid drops this
@@ -26,7 +26,7 @@ struct ContainerCard: View {
     var onStop: () -> Void
     var onRestart: () -> Void
     var onEdit: () -> Void = {}
-    var onUpdate: () -> Void = {}
+    var onRebuild: () -> Void = {}
     var onDelete: () -> Void
     var onClose: () -> Void = {}
     var onSelectMultiple: () -> Void = {}
@@ -289,8 +289,9 @@ struct ContainerCard: View {
             Button { onSelectMultiple() } label: { Label("Select Multiple", systemImage: "checklist") }
         }
         Button { onEdit() } label: { Label("Edit…", systemImage: "slider.horizontal.3") }
-        if hasImageUpdate {
-            Button { onUpdate() } label: { Label("Update Container…", systemImage: "arrow.down.circle") }
+        Button { onRebuild() } label: {
+            Label(imageUpdateState.requiresUpdate ? AppText.updateContainerAction : AppText.rebuildContainerAction,
+                  systemImage: imageUpdateState.requiresUpdate ? "arrow.down.circle" : "arrow.triangle.2.circlepath")
         }
         UI.Copy.ValueLabel("Copy ID", value: snapshot.id)
         Divider()
@@ -390,6 +391,12 @@ struct ContainerCard: View {
             footerAction("play.fill", help: AppText.start, tint: tint, action: onStart)
         }
         footerAction("slider.horizontal.3", help: AppText.edit, action: onEdit)
+        if imageUpdateState.requiresUpdate {
+            footerAction("arrow.down.circle",
+                         help: AppText.updateContainer,
+                         tint: .orange,
+                         action: onRebuild)
+        }
         footerAction("trash", help: AppText.delete, role: .destructive) { confirmingDelete = true }
     }
 

--- a/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
@@ -12,12 +12,21 @@ struct ContainersGridView: View {
         let placement: ContainerGridCardPlacement
     }
 
+    private struct RebuildRequest: Identifiable {
+        let snapshot: Core.Container.Snapshot
+        let updateState: Core.Image.ContainerUpdateState
+
+        var id: String { snapshot.scopedID }
+        var isUpdate: Bool { updateState.requiresUpdate }
+    }
+
     @Environment(AppModel.self) private var app
     @Environment(UIState.self) private var ui
     @Environment(\.morphSafeAreaManager) private var safeAreaManager
 
     @State private var detail: DetailSource?
     @State private var deleting: Core.Container.Snapshot?
+    @State private var rebuilding: RebuildRequest?
     @State private var selecting = false
     @State private var selection: Set<String> = []
     /// Drives the in-place grow: false = card sits in its grid slot, true = promoted to the centered
@@ -126,6 +135,18 @@ struct ContainersGridView: View {
             Button("Cancel", role: .cancel) { deleting = nil }
         } message: {
             Text("This removes the container. This can't be undone.")
+        }
+        .confirmationDialog(
+            rebuildConfirmationTitle,
+            isPresented: Binding(get: { rebuilding != nil }, set: { if !$0 { rebuilding = nil } }),
+            presenting: rebuilding
+        ) { request in
+            Button(request.isUpdate ? AppText.updateContainer : AppText.rebuildContainer, role: .destructive) {
+                applyRebuild(request)
+            }
+            Button("Cancel", role: .cancel) { rebuilding = nil }
+        } message: { request in
+            Text(request.isUpdate ? AppText.updateContainerConfirmation : AppText.rebuildContainerConfirmation)
         }
         // Network-level actions.
         .task { await app.refreshNetworks() }
@@ -295,6 +316,7 @@ struct ContainersGridView: View {
         let style = app.containerStyle(for: snapshot)
         let key = snapshot.scopedID
         let hasStyleOverride = app.personalization.hasOverride(id: key)
+        let imageUpdateState = app.containerImageUpdateState(for: snapshot)
         return ContainerCardMetricsRenderer(
             metrics: store.metricsState(for: key),
             snapshot: snapshot,
@@ -304,8 +326,7 @@ struct ContainersGridView: View {
             statsNormalization: app.statsNormalizationContext,
             selectedWidgetIndex: selectedWidgetBinding(for: key),
             isBusy: store.busyIDs.contains(key),
-            hasImageUpdate: app.imageUpdateStatus(for: snapshot.image,
-                                                  runtimeKind: snapshot.runtimeKind).state == .updateAvailable,
+            imageUpdateState: imageUpdateState,
             isExpanded: isExpanded,
             cornerRadiusOverride: cornerRadiusOverride,
             controlsVisible: controlsVisible,
@@ -314,7 +335,7 @@ struct ContainersGridView: View {
             onStop: { lifecycleAction { await store.stop(key) } },
             onRestart: { lifecycleAction { await store.restart(key) } },
             onEdit: { ui.openCreationPanel(editing: snapshot) },
-            onUpdate: { updateContainer(snapshot) },
+            onRebuild: { rebuilding = RebuildRequest(snapshot: snapshot, updateState: imageUpdateState) },
             onDelete: { deleting = snapshot },
             onClose: closeDetail,
             onSelectMultiple: { beginSelecting(key) },
@@ -428,10 +449,23 @@ struct ContainersGridView: View {
         }
     }
 
-    private func updateContainer(_ snapshot: Core.Container.Snapshot) {
+    private var rebuildConfirmationTitle: String {
+        guard let rebuilding else { return AppText.rebuildContainer }
+        let name = app.containerStyle(for: rebuilding.snapshot)
+            .displayName(fallback: rebuilding.snapshot.id)
+        return rebuilding.isUpdate
+            ? AppText.updateContainerTitle(name)
+            : AppText.rebuildContainerTitle(name)
+    }
+
+    private func applyRebuild(_ request: RebuildRequest) {
+        rebuilding = nil
+        if detail?.snapshot.scopedID == request.snapshot.scopedID {
+            closeDetail()
+        }
         Task {
-            if await app.pullImageUpdate(snapshot.image, runtimeKind: snapshot.runtimeKind) {
-                ui.openCreationPanel(editing: snapshot)
+            if await app.rebuildContainer(request.snapshot) {
+                lifecycleFeedback &+= 1
             }
         }
     }
@@ -478,7 +512,7 @@ private struct ContainerCardMetricsRenderer: View {
     let statsNormalization: Core.Metrics.NormalizationContext
     let selectedWidgetIndex: Binding<Int>
     let isBusy: Bool
-    let hasImageUpdate: Bool
+    let imageUpdateState: Core.Image.ContainerUpdateState
     let isExpanded: Bool
     let cornerRadiusOverride: CGFloat?
     let controlsVisible: Bool
@@ -487,7 +521,7 @@ private struct ContainerCardMetricsRenderer: View {
     let onStop: () -> Void
     let onRestart: () -> Void
     let onEdit: () -> Void
-    let onUpdate: () -> Void
+    let onRebuild: () -> Void
     let onDelete: () -> Void
     let onClose: () -> Void
     let onSelectMultiple: () -> Void
@@ -507,7 +541,7 @@ private struct ContainerCardMetricsRenderer: View {
             statsNormalization: statsNormalization,
             histories: metrics.historyByMetric,
             isBusy: isBusy,
-            hasImageUpdate: hasImageUpdate,
+            imageUpdateState: imageUpdateState,
             isExpanded: isExpanded,
             cornerRadiusOverride: cornerRadiusOverride,
             controlsVisible: controlsVisible,
@@ -516,7 +550,7 @@ private struct ContainerCardMetricsRenderer: View {
             onStop: onStop,
             onRestart: onRestart,
             onEdit: onEdit,
-            onUpdate: onUpdate,
+            onRebuild: onRebuild,
             onDelete: onDelete,
             onClose: onClose,
             onSelectMultiple: onSelectMultiple,

--- a/Sources/ContainedApp/Presentation/Localization/AppLocalization.swift
+++ b/Sources/ContainedApp/Presentation/Localization/AppLocalization.swift
@@ -42,6 +42,40 @@ enum AppText {
     static var stop: String { string("common.stop", defaultValue: "Stop") }
     static var restart: String { string("common.restart", defaultValue: "Restart") }
     static var working: String { string("common.working", defaultValue: "Working...") }
+    static var rebuildContainer: String {
+        string("container.rebuild", defaultValue: "Rebuild Container")
+    }
+    static var rebuildContainerAction: String {
+        string("container.rebuild.action", defaultValue: "Rebuild Container…")
+    }
+    static var updateContainer: String {
+        string("container.update", defaultValue: "Update Container")
+    }
+    static var updateContainerAction: String {
+        string("container.update.action", defaultValue: "Update Container…")
+    }
+    static var rebuildContainerConfirmation: String {
+        string("container.rebuild.confirmation", defaultValue: "Contained will replace this container from its current image. Volumes, configuration, local style, health settings, and its running or stopped state are preserved. Data not stored in volumes is lost.")
+    }
+    static var updateContainerConfirmation: String {
+        string("container.update.confirmation", defaultValue: "Contained will pull the latest image if needed, then replace this container. Volumes, configuration, local style, health settings, and its running or stopped state are preserved. Data not stored in volumes is lost.")
+    }
+
+    static func rebuildContainerTitle(_ name: String) -> String {
+        dynamicString("container.rebuild.title", defaultValue: "Rebuild \(name)?")
+    }
+
+    static func updateContainerTitle(_ name: String) -> String {
+        dynamicString("container.update.title", defaultValue: "Update \(name)?")
+    }
+
+    static func rebuiltContainer(_ name: String) -> String {
+        dynamicString("container.rebuild.completed", defaultValue: "Rebuilt \(name)")
+    }
+
+    static func updatedContainer(_ image: String) -> String {
+        dynamicString("container.update.completed", defaultValue: "Updated \(image)")
+    }
 
     static var addBuildArgument: String { string("build.addBuildArgument", defaultValue: "Add build argument") }
     static var buildImage: String { string("build.buildImage", defaultValue: "Build image") }

--- a/Sources/ContainedApp/Resources/Localizable.xcstrings
+++ b/Sources/ContainedApp/Resources/Localizable.xcstrings
@@ -1272,7 +1272,37 @@
     "container.created" : {
 
     },
+    "container.rebuild" : {
+
+    },
+    "container.rebuild.action" : {
+
+    },
+    "container.rebuild.completed" : {
+
+    },
+    "container.rebuild.confirmation" : {
+
+    },
+    "container.rebuild.title" : {
+
+    },
     "container.restartedAttempt" : {
+
+    },
+    "container.update" : {
+
+    },
+    "container.update.action" : {
+
+    },
+    "container.update.completed" : {
+
+    },
+    "container.update.confirmation" : {
+
+    },
+    "container.update.title" : {
 
     },
     "container.unhealthy" : {

--- a/Tests/ContainedAppTests/ContainerFormStateTests.swift
+++ b/Tests/ContainedAppTests/ContainerFormStateTests.swift
@@ -492,7 +492,12 @@ struct ContainerFormStateTests {
               "terminal": true
             },
             "resources": { "cpus": 2, "memoryInBytes": 536870912 },
-            "labels": { "team": "infra", "contained.restart": "always" },
+            "labels": {
+              "team": "infra",
+              "contained.restart": "always",
+              "contained.stack": "demo",
+              "contained.private": "discard"
+            },
             "publishedPorts": [
               { "hostAddress": "127.0.0.1", "hostPort": 18080, "containerPort": 8080, "proto": "tcp" }
             ],
@@ -546,6 +551,8 @@ struct ContainerFormStateTests {
         #expect(spec.ports.first?.spec == "127.0.0.1:18080:8080")
         #expect(spec.sockets.first?.spec == "/tmp/app.sock:/run/app.sock")
         #expect(spec.labels.contains { $0.key == "team" && $0.value == "infra" })
+        #expect(spec.labels.contains { $0.key == "contained.stack" && $0.value == "demo" })
+        #expect(!spec.labels.contains { $0.key == "contained.private" })
         #expect(spec.restart == .always)
         #expect(spec.readOnly && spec.useInit && spec.rosetta && spec.ssh && spec.virtualization)
     }

--- a/Tests/ContainedAppTests/ContainerImageUpdateTests.swift
+++ b/Tests/ContainedAppTests/ContainerImageUpdateTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+import ContainedCore
+@testable import ContainedApp
+
+@Suite("Container image update state")
+@MainActor
+struct ContainerImageUpdateTests {
+    @Test func pulledTagRemainsReadyUntilContainerIsRecreated() throws {
+        let app = AppModel(database: AppDatabase(isStoredInMemoryOnly: true))
+        let reference = "docker.io/library/nginx:latest"
+        let snapshot = try Core.Container.JSON.decode(
+            Core.Container.Snapshot.self,
+            from: Data("""
+            {
+              "configuration": {
+                "id": "web",
+                "image": {
+                  "reference": "\(reference)",
+                  "descriptor": { "digest": "sha256:old" }
+                },
+                "initProcess": {}
+              },
+              "id": "web",
+              "status": { "state": "running" }
+            }
+            """.utf8),
+            runtimeKind: .appleContainer
+        )
+        let images = try Core.Container.JSON.decode(
+            [Core.Image.Resource].self,
+            from: Data("""
+            [{
+              "configuration": {
+                "name": "\(reference)",
+                "descriptor": { "digest": "sha256:new" }
+              },
+              "id": "new",
+              "variants": []
+            }]
+            """.utf8),
+            runtimeKind: .appleContainer
+        )
+        app.setImages(images)
+        app.imageUpdates[app.imageUpdateKey(reference, runtimeKind: .appleContainer)] =
+            .resolved(localDigest: "sha256:new", remoteDigest: "sha256:new")
+
+        #expect(app.containerImageUpdateState(for: snapshot) == .updateReady)
+
+        app.imageUpdates[app.imageUpdateKey(reference, runtimeKind: .appleContainer)] =
+            .resolved(localDigest: "sha256:new", remoteDigest: "sha256:newer")
+        #expect(app.containerImageUpdateState(for: snapshot) == .updateAvailable)
+    }
+}


### PR DESCRIPTION
## Summary
- detect when a container still uses an older immutable image after its tag changes
- show an Update action on affected container cards and a Rebuild/Update context-menu action
- pull when necessary, recreate with rollback, and preserve configuration, metadata, and prior run state
- retain imported stack identity across recreation

## Verification
- swift test
- swift test (Packages/ContainedCore)
- xcodebuild Debug build
- xcodebuild Debug test (112 tests)
- ./Scripts/check.sh repo
- ./Scripts/package.sh app debug
- git diff --check