### PR TITLE
Preserve Apple named volumes during rebuilds

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Rebuilding Apple containers now preserves named volumes instead of treating their backing disk images as bind-mounted directories, and resolves replacement and recovery configuration before deleting the original container.

--- a/Packages/ContainedCore/Sources/ContainedCore/Runtime/ClientDefaults.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Runtime/ClientDefaults.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 extension RuntimeContainerClient {
+    func prepareCreateRequest(_ request: Core.Container.CreateRequest) async throws -> Core.Container.CreateRequest {
+        request
+    }
+
     func listContainers() async throws -> [Core.Container.Snapshot] {
         try await listContainers(all: true)
     }
@@ -32,6 +36,10 @@ extension RuntimeContainerClient {
     @discardableResult func recreateContainer(originalID: String,
                                              replacement: Core.Container.CreateRequest,
                                              rollback: Core.Container.CreateRequest) async throws -> Core.Container.CreateResult {
+        // Resolve runtime-owned resources before touching the original. Adapters may need inventory
+        // lookups to turn inspected implementation details back into stable create arguments.
+        let replacement = try await prepareCreateRequest(replacement)
+        let rollback = try await prepareCreateRequest(rollback)
         _ = try? await stop([originalID])
         let deletedOriginal: Bool
         do {

--- a/Packages/ContainedCore/Sources/ContainedCore/Runtime/ClientProtocols.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Runtime/ClientProtocols.swift
@@ -10,6 +10,7 @@ protocol RuntimeContainerClient: RuntimeDescribing {
     func streamStats(ids: [String]) -> AsyncThrowingStream<[Core.Metrics.RuntimeStatsSnapshot], Error>
     func streamLogs(id: String, follow: Bool, tail: Int?, boot: Bool) -> AsyncThrowingStream<String, Error>
     func previewCreateCommand(for request: Core.Container.CreateRequest) throws -> Core.Command.Preview
+    func prepareCreateRequest(_ request: Core.Container.CreateRequest) async throws -> Core.Container.CreateRequest
     @discardableResult func createContainer(_ request: Core.Container.CreateRequest) async throws -> Core.Container.CreateResult
     @discardableResult func runContainer(arguments: [String]) async throws -> Data
     @discardableResult func start(_ ids: [String]) async throws -> Data

--- a/Packages/ContainedCore/Sources/ContainedCore/Runtimes/AppleContainer/Client/Client.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Runtimes/AppleContainer/Client/Client.swift
@@ -96,7 +96,27 @@ struct AppleContainerClient: Sendable {
         AppleContainerCreateTranslator.preview(for: request)
     }
 
+    func prepareCreateRequest(_ request: Core.Container.CreateRequest) async throws -> Core.Container.CreateRequest {
+        guard request.volumes.contains(where: {
+            Self.standardizedPath($0.source).hasSuffix("/volume.img")
+        }) else { return request }
+
+        let runtimeVolumes = try await volumes()
+        let namesByBackingPath = runtimeVolumes.reduce(into: [String: String]()) { result, volume in
+            guard let source = volume.configuration.source else { return }
+            result[Self.standardizedPath(source)] = volume.name
+        }
+
+        var prepared = request
+        prepared.volumes = request.volumes.map { mount in
+            guard let name = namesByBackingPath[Self.standardizedPath(mount.source)] else { return mount }
+            return Core.Container.VolumeMount(source: name, target: mount.target, readOnly: mount.readOnly)
+        }
+        return prepared
+    }
+
     @discardableResult func createContainer(_ request: Core.Container.CreateRequest) async throws -> Core.Container.CreateResult {
+        let request = try await prepareCreateRequest(request)
         let data = try await runner.run(ContainerCommands.run(request))
         return AppleContainerCreateTranslator.result(from: data, request: request)
     }
@@ -116,6 +136,10 @@ struct AppleContainerClient: Sendable {
 
     func volumes() async throws -> [Core.Volume.Resource] {
         try await decode([Core.Volume.Resource].self, ContainerCommands.volumeList(), "volume list")
+    }
+
+    private static func standardizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.path
     }
 
     func images() async throws -> [Core.Image.Resource] {


### PR DESCRIPTION
## Summary
- resolve Apple runtime volume backing paths back to their named-volume identifiers before container creation
- preflight replacement and rollback resource resolution before stopping or deleting the original container
- preserve normal bind mounts and other runtime behavior

## Root cause
Apple container inspection reports a named volume as its backing `volume.img` path. Rebuild translated that implementation path directly into `--volume`, causing the runtime to treat the disk image as a directory bind mount and fail with `ENOTDIR`. Rollback inherited the same invalid mount after the original had already been deleted.

## Impact
Apple containers using named volumes can now be rebuilt or updated without losing the container when its configuration is reconstructed. The affected local `profilarr` instance was also recovered using its intact `profilarr-config` volume.

## Verification
- `swift build`
- `swift test` (120 existing tests)
- `swift build` in `Packages/ContainedCore`
- `swift test` in `Packages/ContainedCore` (107 existing tests)
- `./Scripts/check.sh repo`
- Xcode Debug build
- `git diff --check`

No new regression tests were added per maintainer direction.