### PR TITLE
Preserve image customization across updates

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Image and image-group customization now follows normalized image references, preserving existing styles when pulls replace a tag's digest or runtimes report an equivalent reference spelling.

--- a/Documentation/Features/Images.md
+++ b/Documentation/Features/Images.md
@@ -11,6 +11,11 @@ where that tag exists locally. For example, Docker `nginx:latest` and Apple
 container `nginx:latest` share registry/update metadata but remain separate
 runtime-owned local tags.
 
+Image and image-group customization is stored against normalized logical
+references rather than content digests. Pulling a newer image therefore keeps
+the existing icon, tint, name, and card appearance even though the underlying
+digest changes.
+
 Common actions:
 
 - run image

--- a/Sources/ContainedApp/App/AppModel+ResourceStyles.swift
+++ b/Sources/ContainedApp/App/AppModel+ResourceStyles.swift
@@ -16,17 +16,19 @@ extension AppModel {
     }
 
     func imageStyle(for reference: String) -> Personalization {
-        let groupID = imageGroupID(containing: reference)
-        return personalization.imageDefault(for: reference, groupID: groupID) ?? defaultImageStyle
+        personalization.imageDefault(for: reference, group: localImageGroup(containing: reference)) ?? defaultImageStyle
     }
 
     func imageGroupStyle(for group: Core.Image.LocalTagGroup) -> Personalization {
-        personalization.imageGroupDefault(for: group.id) ?? defaultImageStyle
+        personalization.imageGroupDefault(for: group) ?? defaultImageStyle
     }
 
     /// The group's style by id, used where only the id is known, such as a tag resolving its parent.
     func imageGroupStyle(forID id: String) -> Personalization {
-        personalization.imageGroupDefault(for: id) ?? defaultImageStyle
+        if let group = localImageGroup(id: id) {
+            return personalization.imageGroupDefault(for: group) ?? defaultImageStyle
+        }
+        return personalization.imageGroupDefault(forLegacyID: id) ?? defaultImageStyle
     }
 
     func volumeStyle(for name: String) -> Personalization {
@@ -36,10 +38,9 @@ extension AppModel {
     }
 
     func containerStyle(for snapshot: Core.Container.Snapshot) -> Personalization {
-        let groupID = imageGroupID(containing: snapshot.image)
         return personalization.resolved(id: snapshot.scopedID,
                                         image: snapshot.image,
-                                        groupID: groupID,
+                                        group: localImageGroup(containing: snapshot.image),
                                         fallback: defaultImageStyle)
     }
 
@@ -80,16 +81,21 @@ extension AppModel {
         return result
     }
 
-    private func imageGroupID(containing reference: String) -> String? {
-        if let cached = imageGroupIDByReferenceCache[reference] {
-            return cached
+    func localImageGroup(id: String) -> Core.Image.LocalTagGroup? {
+        localImageGroups().first { $0.id == id }
+    }
+
+    func localImageGroup(containing reference: String) -> Core.Image.LocalTagGroup? {
+        let referenceKey = Core.Registry.ImageReference.normalizedKey(reference)
+        if let cached = imageGroupIDByReferenceCache[referenceKey] {
+            return localImageGroup(id: cached)
         }
 
         for group in localImageGroups() {
             for groupReference in group.references {
-                imageGroupIDByReferenceCache[groupReference] = group.id
+                imageGroupIDByReferenceCache[Core.Registry.ImageReference.normalizedKey(groupReference)] = group.id
             }
         }
-        return imageGroupIDByReferenceCache[reference]
+        return imageGroupIDByReferenceCache[referenceKey].flatMap(localImageGroup(id:))
     }
 }

--- a/Sources/ContainedApp/App/AppModel.swift
+++ b/Sources/ContainedApp/App/AppModel.swift
@@ -240,6 +240,7 @@ final class AppModel {
 
     func setImages(_ images: [Core.Image.Resource]) {
         guard images != self.images else { return }
+        personalization.stabilizeImageGroupDefaults(for: localImageGroups())
         self.images = images
         imageGroupsCache = nil
         imageGroupIDByReferenceCache.removeAll(keepingCapacity: true)

--- a/Sources/ContainedApp/Features/Containers/Customization/CustomizeSheet.swift
+++ b/Sources/ContainedApp/Features/Containers/Customization/CustomizeSheet.swift
@@ -13,7 +13,7 @@ struct CustomizeSheet: View {
     enum Target: Identifiable, Hashable {
         case container(Core.Container.Snapshot)
         case image(reference: String)
-        case imageGroup(id: String, reference: String)
+        case imageGroup(Core.Image.LocalTagGroup)
         case imageTag(reference: String, groupID: String?)
         case volume(name: String)
 
@@ -21,7 +21,7 @@ struct CustomizeSheet: View {
             switch self {
             case .container(let snapshot): return "container:\(snapshot.scopedID)"
             case .image(let reference): return "image:\(reference)"
-            case .imageGroup(let id, _): return "image-group:\(id)"
+            case .imageGroup(let group): return "image-group:\(group.id)"
             case .imageTag(let reference, let groupID): return "image-tag:\(groupID ?? "none"):\(reference)"
             case .volume(let name): return "volume:\(name)"
             }
@@ -31,7 +31,7 @@ struct CustomizeSheet: View {
             switch self {
             case .container(let snapshot): return snapshot.image
             case .image(let reference): return reference
-            case .imageGroup(_, let reference): return reference
+            case .imageGroup(let group): return group.primaryReference
             case .imageTag(let reference, _): return reference
             case .volume(let name): return name
             }
@@ -54,9 +54,13 @@ struct CustomizeSheet: View {
         var previewSnapshot: Core.Container.Snapshot {
             switch self {
             case .container(let snapshot): return snapshot
-            case .image(let reference), .imageGroup(_, let reference), .imageTag(let reference, _):
+            case .image(let reference), .imageTag(let reference, _):
                 return .placeholder(id: Format.shortImage(reference),
                                     image: reference,
+                                    runtimeKind: AppRuntimeIntent.placeholderKind)
+            case .imageGroup(let group):
+                return .placeholder(id: Format.shortImage(group.primaryReference),
+                                    image: group.primaryReference,
                                     runtimeKind: AppRuntimeIntent.placeholderKind)
             case .volume(let name):
                 return .placeholder(id: name,
@@ -332,8 +336,8 @@ struct CustomizeSheet: View {
         switch target {
         case .image(let reference), .imageTag(let reference, _):
             return app.personalization.imageDefault(for: reference) != nil
-        case .imageGroup(let id, _):
-            return app.personalization.imageGroupDefault(for: id) != nil
+        case .imageGroup(let group):
+            return app.personalization.imageGroupDefault(for: group) != nil
         case .container(let snapshot):
             return app.personalization.hasOverride(id: snapshot.scopedID)
         case .volume(let name):
@@ -369,8 +373,8 @@ struct CustomizeSheet: View {
             let own = app.personalization.imageDefault(for: reference)
             overridesInheritedStyle = own != nil
             style = own ?? inheritedStyle()
-        case .imageGroup(let id, _):
-            let own = app.personalization.imageGroupDefault(for: id)
+        case .imageGroup(let group):
+            let own = app.personalization.imageGroupDefault(for: group)
             overridesInheritedStyle = own != nil
             style = own ?? inheritedStyle()
         case .volume(let name):
@@ -395,11 +399,11 @@ struct CustomizeSheet: View {
             } else {
                 app.personalization.clearImageDefault(for: reference)
             }
-        case .imageGroup(let id, _):
+        case .imageGroup(let group):
             if overridesInheritedStyle {
-                app.personalization.setImageGroupDefault(style, for: id)
+                app.personalization.setImageGroupDefault(style, for: group)
             } else {
-                app.personalization.clearImageGroupDefault(for: id)
+                app.personalization.clearImageGroupDefault(for: group)
             }
         case .container(let snapshot):
             if overridesInheritedStyle {
@@ -417,8 +421,8 @@ struct CustomizeSheet: View {
         switch target {
         case .image(let reference), .imageTag(let reference, _):
             app.personalization.clearImageDefault(for: reference)
-        case .imageGroup(let id, _):
-            app.personalization.clearImageGroupDefault(for: id)
+        case .imageGroup(let group):
+            app.personalization.clearImageGroupDefault(for: group)
         case .container(let snapshot):
             app.personalization.clearOverride(id: snapshot.scopedID)
         case .volume(let name):
@@ -454,8 +458,8 @@ struct CustomizeSheet: View {
             return app.personalization.hasOverride(id: snapshot.scopedID) ? app.containerStyle(for: snapshot) : inheritedStyle()
         case .image(let reference), .imageTag(let reference, _):
             return app.personalization.imageDefault(for: reference) ?? inheritedStyle()
-        case .imageGroup(let id, _):
-            return app.personalization.imageGroupDefault(for: id) ?? inheritedStyle()
+        case .imageGroup(let group):
+            return app.personalization.imageGroupDefault(for: group) ?? inheritedStyle()
         case .volume:
             return inheritedStyle()
         }

--- a/Sources/ContainedApp/Features/Images/Style/CardStyleButton.swift
+++ b/Sources/ContainedApp/Features/Images/Style/CardStyleButton.swift
@@ -39,8 +39,8 @@ private extension CustomizeSheet.Target {
             return app.personalization.hasOverride(id: snapshot.scopedID)
         case .image(let reference), .imageTag(let reference, _):
             return app.personalization.imageDefault(for: reference) != nil
-        case .imageGroup(let id, _):
-            return app.personalization.imageGroupDefault(for: id) != nil
+        case .imageGroup(let group):
+            return app.personalization.imageGroupDefault(for: group) != nil
         case .volume:
             return true
         }

--- a/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarImageGroupCard.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarImageGroupCard.swift
@@ -104,7 +104,7 @@ struct ToolbarImageGroupCard: View {
                             pages: imagePages) {
             if let image {
                 CardStyleButton(style: resolved,
-                                target: .imageGroup(id: group.id, reference: group.primaryReference),
+                                target: .imageGroup(group),
                                 help: "Customize image style",
                                 accessibilityLabel: AppText.customizeImageStyleAccessibility(Format.shortImage(image.reference)))
             } else {

--- a/Sources/ContainedApp/Personalization/PersonalizationStore.swift
+++ b/Sources/ContainedApp/Personalization/PersonalizationStore.swift
@@ -18,13 +18,20 @@ final class PersonalizationStore {
         static let volumeStyles = "personalizationVolumeStyles"
         static let defaultImageStyle = "personalizationDefaultImageStyle"
     }
+    private static let imageReferencePrefix = "image-ref:"
+    private static let imageGroupReferencePrefix = "image-group-ref:"
+    private static let legacyImageGroupPrefix = "image-group:"
 
     init(database: AppDatabase = AppDatabase()) {
         self.database = database
         overrides = Self.load(database, Keys.overrides)
-        imageDefaults = Self.load(database, Keys.imageDefaults)
+        let loadedImageDefaults = Self.load(database, Keys.imageDefaults)
+        imageDefaults = Self.migratedImageDefaults(loadedImageDefaults, database: database)
         volumeStyles = Self.load(database, Keys.volumeStyles)
         defaultImageStyle = Self.loadStyle(database, Keys.defaultImageStyle) ?? Personalization()
+        if imageDefaults != loadedImageDefaults {
+            Self.persist(database, Keys.imageDefaults, imageDefaults)
+        }
     }
 
     func backupSnapshot() -> PersonalizationBackup {
@@ -35,13 +42,14 @@ final class PersonalizationStore {
     }
 
     func applyBackup(_ snapshot: PersonalizationBackup, replace: Bool) {
+        let importedImageDefaults = Self.migratedImageDefaults(snapshot.imageDefaults, database: database)
         if replace {
             overrides = snapshot.overrides
-            imageDefaults = snapshot.imageDefaults
+            imageDefaults = importedImageDefaults
             volumeStyles = snapshot.volumeStyles
         } else {
             overrides.merge(snapshot.overrides) { _, imported in imported }
-            imageDefaults.merge(snapshot.imageDefaults) { _, imported in imported }
+            imageDefaults.merge(importedImageDefaults) { _, imported in imported }
             volumeStyles.merge(snapshot.volumeStyles) { _, imported in imported }
         }
         defaultImageStyle = snapshot.defaultImageStyle
@@ -53,9 +61,17 @@ final class PersonalizationStore {
 
     func purgeOrphans(liveContainerIDs: Set<String>, liveImageRefs: Set<String>) -> Int {
         let before = overrides.count + imageDefaults.count + volumeStyles.count
+        let normalizedLiveImageRefs = Set(liveImageRefs.map(Core.Registry.ImageReference.normalizedKey))
         overrides = overrides.filter { liveContainerIDs.contains($0.key) }
         imageDefaults = imageDefaults.filter { key, _ in
-            key.hasPrefix("image-group:") || liveImageRefs.contains(key)
+            if key.hasPrefix(Self.legacyImageGroupPrefix) { return true }
+            if let reference = Self.reference(from: key, prefix: Self.imageReferencePrefix) {
+                return normalizedLiveImageRefs.contains(reference)
+            }
+            if let reference = Self.reference(from: key, prefix: Self.imageGroupReferencePrefix) {
+                return normalizedLiveImageRefs.contains(reference)
+            }
+            return normalizedLiveImageRefs.contains(Core.Registry.ImageReference.normalizedKey(key))
         }
         persist(Keys.overrides, overrides)
         persist(Keys.imageDefaults, imageDefaults)
@@ -98,9 +114,9 @@ final class PersonalizationStore {
     /// Resolve a container's effective style: per-container override -> image default -> fallback.
     func resolved(id: String,
                   image: String,
-                  groupID: String? = nil,
+                  group: Core.Image.LocalTagGroup? = nil,
                   fallback: Personalization = Personalization()) -> Personalization {
-        Self.meaningful(overrides[id]) ?? imageDefault(for: image, groupID: groupID) ?? fallback
+        Self.meaningful(overrides[id]) ?? imageDefault(for: image, group: group) ?? fallback
     }
 
     // MARK: Per-container overrides
@@ -123,44 +139,73 @@ final class PersonalizationStore {
 
     // MARK: Image-level defaults
 
-    func imageDefault(for image: String) -> Personalization? { Self.meaningful(imageDefaults[image]) }
-
-    func imageDefault(for image: String, groupID: String?) -> Personalization? {
-        Self.meaningful(imageDefaults[image]) ?? groupID.flatMap { Self.meaningful(imageDefaults[Self.imageGroupKey($0)]) }
+    func imageDefault(for image: String) -> Personalization? {
+        Self.meaningful(imageDefaults[Self.imageReferenceKey(image)])
     }
 
-    func imageGroupDefault(for groupID: String) -> Personalization? { Self.meaningful(imageDefaults[Self.imageGroupKey(groupID)]) }
+    func imageDefault(for image: String, group: Core.Image.LocalTagGroup?) -> Personalization? {
+        imageDefault(for: image) ?? group.flatMap(imageGroupDefault(for:))
+    }
+
+    func imageGroupDefault(for group: Core.Image.LocalTagGroup) -> Personalization? {
+        for key in Self.imageGroupReferenceKeys(group.references) {
+            if let style = Self.meaningful(imageDefaults[key]) { return style }
+        }
+        return imageGroupDefault(forLegacyID: group.id)
+    }
+
+    func imageGroupDefault(forLegacyID groupID: String) -> Personalization? {
+        Self.meaningful(imageDefaults[Self.legacyImageGroupKey(groupID)])
+    }
 
     func setImageDefault(_ personalization: Personalization, for image: String) {
         if personalization.isDefault {
             clearImageDefault(for: image)
             return
         }
-        imageDefaults[image] = personalization.normalizedForPersistence()
+        imageDefaults[Self.imageReferenceKey(image)] = personalization.normalizedForPersistence()
         persist(Keys.imageDefaults, imageDefaults)
     }
 
-    func setImageGroupDefault(_ personalization: Personalization, for groupID: String) {
+    func setImageGroupDefault(_ personalization: Personalization, for group: Core.Image.LocalTagGroup) {
         if personalization.isDefault {
-            clearImageGroupDefault(for: groupID)
+            clearImageGroupDefault(for: group)
             return
         }
-        imageDefaults[Self.imageGroupKey(groupID)] = personalization.normalizedForPersistence()
+        let style = personalization.normalizedForPersistence()
+        for key in Self.imageGroupReferenceKeys(group.references) {
+            imageDefaults[key] = style
+        }
+        imageDefaults[Self.legacyImageGroupKey(group.id)] = nil
         persist(Keys.imageDefaults, imageDefaults)
     }
 
     func clearImageDefault(for image: String) {
-        imageDefaults[image] = nil
+        imageDefaults[Self.imageReferenceKey(image)] = nil
         persist(Keys.imageDefaults, imageDefaults)
     }
 
-    func clearImageGroupDefault(for groupID: String) {
-        imageDefaults[Self.imageGroupKey(groupID)] = nil
+    func clearImageGroupDefault(for group: Core.Image.LocalTagGroup) {
+        for key in Self.imageGroupReferenceKeys(group.references) {
+            imageDefaults[key] = nil
+        }
+        imageDefaults[Self.legacyImageGroupKey(group.id)] = nil
         persist(Keys.imageDefaults, imageDefaults)
     }
 
-    static func imageGroupKey(_ groupID: String) -> String {
-        "image-group:\(groupID)"
+    /// Move digest-keyed group styles onto the group's logical references before inventory changes.
+    func stabilizeImageGroupDefaults(for groups: [Core.Image.LocalTagGroup]) {
+        var changed = false
+        for group in groups {
+            guard let style = imageGroupDefault(for: group) else { continue }
+            for key in Self.imageGroupReferenceKeys(group.references) where imageDefaults[key] == nil {
+                imageDefaults[key] = style
+                changed = true
+            }
+            let legacyKey = Self.legacyImageGroupKey(group.id)
+            if imageDefaults.removeValue(forKey: legacyKey) != nil { changed = true }
+        }
+        if changed { persist(Keys.imageDefaults, imageDefaults) }
     }
 
     // MARK: App-wide image default
@@ -241,6 +286,62 @@ final class PersonalizationStore {
 
     private func persist(_ key: String, _ value: [String: Personalization]) {
         Self.persist(database, key, value)
+    }
+
+    private static func migratedImageDefaults(_ values: [String: Personalization],
+                                              database: AppDatabase) -> [String: Personalization] {
+        let recordsByIdentity = Dictionary(database.fetch(ImageRecord.self).map { ($0.identity, $0) },
+                                           uniquingKeysWith: { first, _ in first })
+        let ordered = values.sorted { lhs, rhs in
+            let lhsCanonical = isCanonicalImageKey(lhs.key)
+            let rhsCanonical = isCanonicalImageKey(rhs.key)
+            if lhsCanonical != rhsCanonical { return lhsCanonical }
+            return lhs.key < rhs.key
+        }
+        var migrated: [String: Personalization] = [:]
+        for (key, style) in ordered {
+            let targetKey: String
+            if let reference = reference(from: key, prefix: imageReferencePrefix) {
+                targetKey = imageReferenceKey(reference)
+            } else if let reference = reference(from: key, prefix: imageGroupReferencePrefix) {
+                targetKey = imageGroupReferenceKey(reference)
+            } else if let identity = reference(from: key, prefix: legacyImageGroupPrefix) {
+                guard let reference = recordsByIdentity[identity]?.primaryReference else {
+                    migrated[key] = migrated[key] ?? style
+                    continue
+                }
+                targetKey = imageGroupReferenceKey(reference)
+            } else {
+                targetKey = imageReferenceKey(key)
+            }
+            migrated[targetKey] = migrated[targetKey] ?? style
+        }
+        return migrated
+    }
+
+    private static func isCanonicalImageKey(_ key: String) -> Bool {
+        key.hasPrefix(imageReferencePrefix) || key.hasPrefix(imageGroupReferencePrefix)
+    }
+
+    private static func imageReferenceKey(_ reference: String) -> String {
+        imageReferencePrefix + Core.Registry.ImageReference.normalizedKey(reference)
+    }
+
+    private static func imageGroupReferenceKey(_ reference: String) -> String {
+        imageGroupReferencePrefix + Core.Registry.ImageReference.normalizedKey(reference)
+    }
+
+    private static func imageGroupReferenceKeys(_ references: [String]) -> [String] {
+        Array(Set(references.map(imageGroupReferenceKey))).sorted()
+    }
+
+    private static func legacyImageGroupKey(_ groupID: String) -> String {
+        legacyImageGroupPrefix + groupID
+    }
+
+    private static func reference(from key: String, prefix: String) -> String? {
+        guard key.hasPrefix(prefix) else { return nil }
+        return String(key.dropFirst(prefix.count))
     }
 }
 

--- a/Tests/ContainedAppTests/PersonalizationStoreTests.swift
+++ b/Tests/ContainedAppTests/PersonalizationStoreTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+import ContainedCore
+@testable import ContainedApp
+
+@Suite("Image personalization identity")
+@MainActor
+struct PersonalizationStoreTests {
+    @Test func imageTagStylesUseCanonicalReferences() {
+        let database = AppDatabase(isStoredInMemoryOnly: true)
+        let store = PersonalizationStore(database: database)
+        var style = Personalization()
+        style.nickname = "Web image"
+
+        store.setImageDefault(style, for: "nginx")
+
+        #expect(store.imageDefault(for: "docker.io/library/nginx:latest") == style)
+        #expect(database.fetch(PersonalizationRecord.self).contains {
+            $0.key == "image-ref:docker.io/library/nginx:latest"
+        })
+    }
+
+    @Test func digestKeyedGroupStyleMigratesThroughRetainedImageRecord() throws {
+        let database = AppDatabase(isStoredInMemoryOnly: true)
+        var style = Personalization()
+        style.nickname = "My image group"
+        database.context.insert(ImageRecord(identity: "sha256:old",
+                                            primaryReference: "nginx:latest",
+                                            digest: "sha256:old"))
+        database.context.insert(PersonalizationRecord(
+            key: "image-group:sha256:old",
+            scopeRaw: "personalizationImageDefaults",
+            valueData: try JSONEncoder().encode(style)
+        ))
+        database.save()
+
+        let store = PersonalizationStore(database: database)
+        let updatedGroup = try imageGroup(reference: "docker.io/library/nginx:latest",
+                                          digest: "sha256:new")
+
+        #expect(store.imageGroupDefault(for: updatedGroup) == style)
+        #expect(database.fetch(PersonalizationRecord.self).contains {
+            $0.key == "image-group-ref:docker.io/library/nginx:latest"
+        })
+    }
+
+    private func imageGroup(reference: String,
+                            digest: String) throws -> Core.Image.LocalTagGroup {
+        let images = try Core.Container.JSON.decode(
+            [Core.Image.Resource].self,
+            from: Data("""
+            [{
+              "configuration": {
+                "name": "\(reference)",
+                "descriptor": { "digest": "\(digest)" }
+              },
+              "id": "\(digest)",
+              "variants": []
+            }]
+            """.utf8),
+            runtimeKind: .appleContainer
+        )
+        return try #require(Core.Image.LocalTagGroup.groups(for: images).first)
+    }
+}


### PR DESCRIPTION
## Summary
- key image and image-group personalization by normalized logical references instead of mutable digests or runtime spelling
- migrate existing digest-keyed and raw-reference customization using retained image inventory records
- preserve group customization before inventory refreshes and update the customization UI to use full image groups
- document the behavior and add focused migration coverage

## Verification
- `swift test --quiet` (122 tests)
- `swift test --quiet` in `Packages/ContainedCore` (107 tests)
- `./Scripts/check.sh repo`
- `xcodebuild -workspace Contained.xcworkspace -scheme Contained -configuration Debug build -quiet`
- `git diff --check`