### PR TITLE
Refine design-system tint customization

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,3 +1,8 @@
+### Changed
+
+- Color selectors now lead with the inherited accent and a custom `#RRGGBB` option before SwiftUI's standard Apple color palette. Selecting custom reveals a dedicated “Custom” row using the host form's normal alignment and `#007AFF` as its example. The app-accent picker inherits the native macOS accent; other pickers inherit the selected app accent, which now scopes both native controls and explicit accent-colored selection, navigation, status, chart, and resource chrome throughout the app.
+- Shared panel and form rows now move wide controls beneath their labels instead of clipping or squeezing important titles.
+
 ### Fixed
 
 - Image and image-group customization now follows normalized image references, preserving existing styles when pulls replace a tag's digest or runtimes report an equivalent reference spelling.

--- a/Documentation/App/Localization.md
+++ b/Documentation/App/Localization.md
@@ -40,7 +40,8 @@ UI.Toolbar.SearchField(text: $query,
     EmptyView()
 }
 
-UI.Control.TintSelector(selection: $settings.accentTint) {
+UI.Control.TintSelector(selection: $settings.accentTint,
+                        customLabel: AppText.customHexColor) {
     $0.localizedDisplayName
 }
 

--- a/Documentation/Architecture/Design-System.md
+++ b/Documentation/Architecture/Design-System.md
@@ -42,6 +42,15 @@ The design system is a building block package. It owns layout, materials,
 tokens, animation behavior, and control anatomy, but it does not own app copy or
 localized resources.
 
+`UI.Panel.Row` and `UI.Form.Row` preserve their label's useful width and
+automatically move a wide trailing control onto the next line when the normal
+label-left/control-right arrangement cannot fit. Stacked controls reclaim the
+full row and align to its leading edge.
+
+Reusable controls should express minimum and ideal widths while remaining
+flexible to the row's available width; stacked controls must not preserve a
+desktop-column width that leaves unused space beside them.
+
 Guidelines:
 
 - user-facing labels, help text, accessibility labels, picker names, page names,
@@ -49,7 +58,7 @@ Guidelines:
 - package APIs that need words take app-supplied strings or semantic item
   titles, such as `UI.Card.Pages.closeLabel`,
   `UI.Toolbar.SearchField.clearSearchLabel`, and `UI.Control.TintSelector`'s
-  `labelForTint`
+  `customLabel` and `labelForTint`
 - app-owned enum labels and dynamic templates flow through `AppText`, which uses
   `String(localized:defaultValue:bundle:)` with English fallbacks today
 - package-owned strings are limited to non-user identifiers such as SF Symbol
@@ -227,6 +236,18 @@ The palette should not degrade rich app objects into plain text. Use
 - `.tint` for appearance color choices
 
 Plain rows are reserved for generic actions such as refresh or opening a page.
+
+## Accent color
+
+Each app scene seeds SwiftUI's `.tint(...)` and `.accentColor(...)` plus ContainedUI's
+`\.designSystemAccentColor` from the resolved app accent. Native controls inherit the tint, explicit
+accent-colored drawing inherits the scoped SwiftUI accent, and components that need a concrete color
+value—including the App Accent swatch—read the design-system environment value. Selection,
+changed-value, and interactive emphasis use `.accentColor`; fixed system colors remain appropriate
+only when color communicates a semantic state or category.
+Hosts reveal `UI.Control.HexTintField` in a sibling form or panel row only while the custom swatch is
+active, preserving the host page's normal label alignment. The app-accent setting supplies the native
+macOS control accent as its inheritance preview; other tint pickers inherit the selected app accent.
 
 ## Tokens
 

--- a/Packages/ContainedUI/README.md
+++ b/Packages/ContainedUI/README.md
@@ -59,11 +59,13 @@ Seed shared material and tint policy once near the app shell:
 
 ```swift
 struct AppRoot: View {
-    let tint = UI.Theme.Tint.azure
+    let tint = UI.Theme.Tint.blue
 
     var body: some View {
         RootContent()
             .tint(tint.color)
+            .accentColor(tint.color)
+            .environment(\.designSystemAccentColor, tint.color)
             .environment(\.modalMaterial, UI.Theme.WindowMaterial.sheet)
             .environment(\.buttonMaterial, UI.Theme.WindowMaterial.glassClear)
             .environment(\.cardMaterial, UI.Theme.WindowMaterial.glassRegular)

--- a/Packages/ContainedUI/Sources/ContainedUI/ContainedUI.docc/ContainedUI.md
+++ b/Packages/ContainedUI/Sources/ContainedUI/ContainedUI.docc/ContainedUI.md
@@ -65,11 +65,20 @@ UI.Panel.Scaffold(width: UI.Panel.Size.settings.width) {
 } content: {
     UI.Panel.Section(header: "Appearance") {
         UI.Panel.Row(title: "Accent") {
-            UI.Control.TintSelector(selection: $tint, labelForTint: label)
+            UI.Control.TintSelector(selection: $tint,
+                                    customLabel: "Custom",
+                                    labelForTint: label)
+        }
+        UI.Panel.Row(title: "Custom") {
+            UI.Control.HexTintField(selection: $tint)
         }
     }
 }
 ```
+
+Seed `.tint(...)`, `.accentColor(...)`, and `\.designSystemAccentColor` at every scene root. The
+first styles native controls, the second scopes explicit accent drawing, and the third gives reusable
+controls such as the App Accent swatch the resolved, live accent color to render.
 
 ```swift
 UI.Form.Grouped {

--- a/Packages/ContainedUI/Sources/ContainedUI/Control/TintSelector.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Control/TintSelector.swift
@@ -1,48 +1,139 @@
 import SwiftUI
 
-/// A row of colored swatches for picking a `UI.Theme.Tint` — each shows its actual color, the selected
-/// one gets a ring.
+/// A horizontally scrolling row of system-color swatches. Pair it with `HexTintField` in a sibling
+/// form or panel row so the editor follows the host page's normal label alignment.
 public extension UI.Control {
     struct TintSelector: View {
+        private enum Choice: Identifiable {
+            case automatic
+            case tint(UI.Theme.Tint)
+            case custom
+
+            var id: String {
+                switch self {
+                case .automatic: "automatic"
+                case .tint(let tint): "tint:\(tint.id)"
+                case .custom: "custom"
+                }
+            }
+        }
+
         private let selection: Binding<UI.Theme.Tint?>
         private let automaticLabel: String?
+        private let customLabel: String
+        private let inheritedAccentColor: Color?
         private let labelForTint: (UI.Theme.Tint) -> String
+        @Environment(\.designSystemAccentColor) private var appAccentColor
+        @State private var canScrollForward = true
 
         public init(selection: Binding<UI.Theme.Tint>,
+                    customLabel: String,
+                    inheritedAccentColor: Color? = nil,
                     labelForTint: @escaping (UI.Theme.Tint) -> String) {
             self.selection = Binding<UI.Theme.Tint?>(
                 get: { selection.wrappedValue },
                 set: { if let newValue = $0 { selection.wrappedValue = newValue } }
             )
             self.automaticLabel = nil
+            self.customLabel = customLabel
+            self.inheritedAccentColor = inheritedAccentColor
             self.labelForTint = labelForTint
         }
 
         public init(optionalSelection: Binding<UI.Theme.Tint?>,
                     automaticLabel: String,
+                    customLabel: String,
+                    inheritedAccentColor: Color? = nil,
                     labelForTint: @escaping (UI.Theme.Tint) -> String) {
             self.selection = optionalSelection
             self.automaticLabel = automaticLabel
+            self.customLabel = customLabel
+            self.inheritedAccentColor = inheritedAccentColor
             self.labelForTint = labelForTint
         }
 
         public var body: some View {
-            HStack(spacing: UI.Tokens.Space.s) {
+            ScrollViewReader { proxy in
+                ScrollView(.horizontal) {
+                    LazyHStack(spacing: UI.Tokens.Space.s) {
+                        ForEach(choices) { choice in
+                            choiceButton(choice)
+                                .id(choice.id)
+                        }
+                    }
+                }
+                .scrollIndicators(.hidden)
+                .scrollBounceBehavior(.basedOnSize)
+                .frame(minWidth: UI.Tokens.FormWidth.tintColorHex,
+                       idealWidth: UI.Tokens.FormWidth.tintSelector,
+                       maxWidth: .infinity,
+                       minHeight: UI.Tokens.IconSize.control,
+                       maxHeight: UI.Tokens.IconSize.control)
+                .onScrollGeometryChange(for: Bool.self) { geometry in
+                    geometry.contentOffset.x + geometry.containerSize.width
+                        < geometry.contentSize.width - 1
+                } action: { _, canScrollForward in
+                    self.canScrollForward = canScrollForward
+                }
+                .mask {
+                    HStack(spacing: 0) {
+                        Rectangle().fill(.white)
+                        if canScrollForward {
+                            LinearGradient(colors: [.white, .clear],
+                                           startPoint: .leading,
+                                           endPoint: .trailing)
+                                .frame(width: UI.Tokens.TintSelector.trailingFadeWidth)
+                        }
+                    }
+                }
+                .onAppear { scrollToSelection(proxy) }
+                .onChange(of: selection.wrappedValue) { _, _ in scrollToSelection(proxy) }
+            }
+        }
+
+        private var choices: [Choice] {
+            var choices: [Choice] = [.tint(.multicolor), .custom]
+            if automaticLabel != nil {
+                choices.append(.automatic)
+            }
+            choices.append(contentsOf: UI.Theme.Tint.allCases
+                .filter { $0 != .multicolor }
+                .map(Choice.tint))
+            return choices
+        }
+
+        @ViewBuilder
+        private func choiceButton(_ choice: Choice) -> some View {
+            switch choice {
+            case .automatic:
                 if let automaticLabel {
-                    Button { selection.wrappedValue = nil } label: { automaticSwatch }
+                    Button {
+                        selection.wrappedValue = nil
+                    } label: { automaticSwatch }
                         .buttonStyle(.plain)
                         .help(automaticLabel)
                         .accessibilityLabel(automaticLabel)
                         .accessibilityAddTraits(selection.wrappedValue == nil ? .isSelected : [])
                 }
-                ForEach(UI.Theme.Tint.allCases) { tint in
-                    let label = labelForTint(tint)
-                    Button { selection.wrappedValue = tint } label: { swatch(tint) }
-                        .buttonStyle(.plain)
-                        .help(label)
-                        .accessibilityLabel(label)
-                        .accessibilityAddTraits(selection.wrappedValue == tint ? .isSelected : [])
-                }
+            case .tint(let tint):
+                let label = labelForTint(tint)
+                Button {
+                    selection.wrappedValue = tint
+                } label: { swatch(tint) }
+                    .buttonStyle(.plain)
+                    .help(label)
+                    .accessibilityLabel(label)
+                    .accessibilityAddTraits(selection.wrappedValue == tint ? .isSelected : [])
+            case .custom:
+                Button {
+                    if selection.wrappedValue?.isCustom != true {
+                        selection.wrappedValue = UI.Theme.Tint(hex: HexTintField.defaultExample)
+                    }
+                } label: { customSwatch }
+                    .buttonStyle(.plain)
+                    .help(customLabel)
+                    .accessibilityLabel(customLabel)
+                    .accessibilityAddTraits(selection.wrappedValue?.isCustom == true ? .isSelected : [])
             }
         }
 
@@ -54,9 +145,77 @@ public extension UI.Control {
         }
 
         private func swatch(_ tint: UI.Theme.Tint) -> some View {
-            SharedTintSwatchMark(color: tint.color,
+            SharedTintSwatchMark(color: tint.followsAccent ? inheritedAccentColor ?? appAccentColor : tint.color,
                                  markerSystemName: tint.followsAccent ? "link" : nil,
                                  selected: selection.wrappedValue == tint)
+        }
+
+        private var customSwatch: some View {
+            let customTint = selection.wrappedValue.flatMap { $0.isCustom ? $0 : nil }
+            return SharedTintSwatchMark(color: customTint?.color ?? Color.secondary.opacity(0.18),
+                                        markerSystemName: "number",
+                                        markerForeground: customTint?.contrastingColor ?? .secondary,
+                                        selected: selection.wrappedValue?.isCustom == true)
+        }
+
+        private func scrollToSelection(_ proxy: ScrollViewProxy) {
+            let id: String
+            if let tint = selection.wrappedValue {
+                id = tint.isCustom ? "custom" : "tint:\(tint.id)"
+            } else {
+                id = "automatic"
+            }
+            withAnimation(.easeOut(duration: 0.18)) {
+                proxy.scrollTo(id, anchor: .center)
+            }
+        }
+    }
+
+    /// The text-field half of a tint picker. Hosts place this in their normal sibling row so its
+    /// label and field align with the rest of that form or panel.
+    struct HexTintField: View {
+        public static let defaultExample = "#007AFF"
+
+        private let selection: Binding<UI.Theme.Tint?>
+        private let example: String
+        @State private var text = ""
+
+        public init(selection: Binding<UI.Theme.Tint>, example: String = defaultExample) {
+            self.selection = Binding<UI.Theme.Tint?>(
+                get: { selection.wrappedValue },
+                set: { if let newValue = $0 { selection.wrappedValue = newValue } }
+            )
+            self.example = example
+        }
+
+        public init(optionalSelection: Binding<UI.Theme.Tint?>, example: String = defaultExample) {
+            self.selection = optionalSelection
+            self.example = example
+        }
+
+        public var body: some View {
+            TextField("", text: $text, prompt: Text(example))
+                .textFieldStyle(.roundedBorder)
+                .font(.body.monospaced())
+                .foregroundStyle(isInvalid ? Color.red : Color.primary)
+                .frame(width: UI.Tokens.FormWidth.tintColorHex)
+                .disabled(!isCustom)
+                .onAppear { synchronizeText() }
+                .onChange(of: selection.wrappedValue) { _, _ in synchronizeText() }
+                .onChange(of: text) { _, value in
+                    guard isCustom, let tint = UI.Theme.Tint(hex: value) else { return }
+                    selection.wrappedValue = tint
+                }
+        }
+
+        private var isCustom: Bool { selection.wrappedValue?.isCustom == true }
+
+        private var isInvalid: Bool {
+            isCustom && !text.isEmpty && UI.Theme.Tint.normalizedHex(text) == nil
+        }
+
+        private func synchronizeText() {
+            text = selection.wrappedValue?.hexValue ?? ""
         }
     }
 }
@@ -67,11 +226,17 @@ public extension UI.Control {
 }
 
 private struct TintSelectorPreview: View {
-    @State private var tint: UI.Theme.Tint? = .azure
+    @State private var tint: UI.Theme.Tint? = .blue
 
     var body: some View {
-        UI.Control.TintSelector(optionalSelection: $tint,
-                                automaticLabel: "Automatic",
-                                labelForTint: { $0.rawValue.capitalized })
+        VStack {
+            UI.Control.TintSelector(optionalSelection: $tint,
+                                    automaticLabel: "Automatic",
+                                    customLabel: "Custom",
+                                    labelForTint: { $0.rawValue.capitalized })
+            if tint?.isCustom == true {
+                UI.Control.HexTintField(optionalSelection: $tint)
+            }
+        }
     }
 }

--- a/Packages/ContainedUI/Sources/ContainedUI/Form/Rows.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Form/Rows.swift
@@ -9,7 +9,7 @@ enum LabelState: Equatable {
     var foregroundStyle: Color {
         switch self {
         case .normal: .primary
-        case .changed: .blue
+        case .changed: .accentColor
         case .invalid: .red
         }
     }
@@ -41,9 +41,9 @@ struct Row<Trailing: View>: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: UI.Tokens.Space.xxs) {
-            HStack(spacing: UI.Tokens.Space.m) {
+            SharedAdaptiveLabeledRow {
                 labelStack
-                Spacer(minLength: UI.Tokens.Space.m)
+            } trailing: {
                 trailing()
             }
             .contentShape(Rectangle())
@@ -78,6 +78,7 @@ struct Row<Trailing: View>: View {
                 UI.Control.InfoButton(info, visible: labelHovering)
             }
         }
+        .fixedSize(horizontal: true, vertical: false)
     }
 
     private var labelState: UI.Form.LabelState {

--- a/Packages/ContainedUI/Sources/ContainedUI/Panel/Section.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Panel/Section.swift
@@ -144,19 +144,9 @@ struct Row<Trailing: View>: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: UI.Tokens.Space.m) {
-                VStack(alignment: .leading, spacing: 1) {
-                    SharedPanelLabel(title: title,
-                                     info: info,
-                                     error: error,
-                                     highlighted: sectionHighlighted,
-                                     hovering: labelHovering)
-                    if let subtitle {
-                        Text(subtitle).font(.caption).foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-                Spacer(minLength: UI.Tokens.Space.m)
+            SharedAdaptiveLabeledRow {
+                labelStack
+            } trailing: {
                 trailing()
             }
             .contentShape(Rectangle())
@@ -166,6 +156,21 @@ struct Row<Trailing: View>: View {
             }
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var labelStack: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            SharedPanelLabel(title: title,
+                             info: info,
+                             error: error,
+                             highlighted: sectionHighlighted,
+                             hovering: labelHovering)
+                .fixedSize(horizontal: true, vertical: false)
+            if let subtitle {
+                Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
     }
 }
 }

--- a/Packages/ContainedUI/Sources/ContainedUI/Shared/AdaptiveLabeledRow.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Shared/AdaptiveLabeledRow.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// Keeps ordinary settings rows horizontal, then moves the control beneath the label when both
+/// cannot retain their useful intrinsic widths. Callers keep ownership of label and control styling.
+struct SharedAdaptiveLabeledRow<Label: View, Trailing: View>: View {
+    @ViewBuilder var label: () -> Label
+    @ViewBuilder var trailing: () -> Trailing
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: UI.Tokens.Space.m) {
+                label()
+                    .layoutPriority(1)
+                Spacer(minLength: UI.Tokens.Space.m)
+                trailing()
+            }
+
+            VStack(alignment: .leading, spacing: UI.Tokens.Space.s) {
+                label()
+                trailing()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}

--- a/Packages/ContainedUI/Sources/ContainedUI/Theme/Theme.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Theme/Theme.swift
@@ -14,31 +14,130 @@ enum Material {
     public static let floatingPanelShadowY: CGFloat = 12
 }
 
-/// A curated color, used consistently for host accent choices and per-surface personalization.
-/// `.multicolor` follows `Color.accentColor`, so package callers can decide whether that means a
-/// global accent, a scoped accent, or the platform default.
-enum Tint: String, CaseIterable, Identifiable, Codable, Sendable {
-    case multicolor, graphite, azure, teal, coral, indigo, green, amber, pink
+/// A system color or custom sRGB hex value, used consistently for host accent choices and
+/// per-surface personalization. The preset list mirrors SwiftUI's standard named colors;
+/// `.multicolor` follows `Color.accentColor`.
+struct Tint: RawRepresentable, CaseIterable, Identifiable, Codable, Hashable, Sendable {
+    public let rawValue: String
 
-    public var id: String { rawValue }
+    public static let multicolor = Tint(canonicalRawValue: "multicolor")
+    public static let gray = Tint(canonicalRawValue: "gray")
+    public static let red = Tint(canonicalRawValue: "red")
+    public static let orange = Tint(canonicalRawValue: "orange")
+    public static let yellow = Tint(canonicalRawValue: "yellow")
+    public static let green = Tint(canonicalRawValue: "green")
+    public static let mint = Tint(canonicalRawValue: "mint")
+    public static let teal = Tint(canonicalRawValue: "teal")
+    public static let cyan = Tint(canonicalRawValue: "cyan")
+    public static let blue = Tint(canonicalRawValue: "blue")
+    public static let indigo = Tint(canonicalRawValue: "indigo")
+    public static let purple = Tint(canonicalRawValue: "purple")
+    public static let pink = Tint(canonicalRawValue: "pink")
+    public static let brown = Tint(canonicalRawValue: "brown")
+    public static let black = Tint(canonicalRawValue: "black")
+    public static let white = Tint(canonicalRawValue: "white")
 
-    /// True for the "follow the host accent" option (rendered with a marker in the swatch row).
-    public var followsAccent: Bool { self == .multicolor }
+    public static let allCases: [Tint] = [
+        .multicolor, .gray, .red, .orange, .yellow, .green, .mint, .teal,
+        .cyan, .blue, .indigo, .purple, .pink, .brown, .black, .white,
+    ]
 
-    public var color: Color {
-        switch self {
-        case .multicolor: return .accentColor
-        case .graphite:   return Color(red: 0.45, green: 0.46, blue: 0.50)
-        case .azure:      return Color(red: 0.14, green: 0.52, blue: 0.92)
-        case .teal:       return Color(red: 0.11, green: 0.62, blue: 0.50)
-        case .coral:      return Color(red: 0.85, green: 0.35, blue: 0.19)
-        case .indigo:     return Color(red: 0.33, green: 0.29, blue: 0.72)
-        case .green:      return Color(red: 0.39, green: 0.60, blue: 0.13)
-        case .amber:      return Color(red: 0.73, green: 0.46, blue: 0.09)
-        case .pink:       return Color(red: 0.83, green: 0.21, blue: 0.34)
+    public init?(rawValue: String) {
+        let migratedRawValue: String
+        switch rawValue.lowercased() {
+        case "graphite": migratedRawValue = Self.gray.rawValue
+        case "azure": migratedRawValue = Self.blue.rawValue
+        case "coral": migratedRawValue = Self.orange.rawValue
+        case "amber": migratedRawValue = Self.yellow.rawValue
+        default: migratedRawValue = rawValue.lowercased()
+        }
+
+        if Self.allCases.contains(where: { $0.rawValue == migratedRawValue }) {
+            self.init(canonicalRawValue: migratedRawValue)
+        } else if let hex = Self.normalizedHex(migratedRawValue) {
+            self.init(canonicalRawValue: hex)
+        } else {
+            return nil
         }
     }
 
+    public init?(hex: String) {
+        guard let normalized = Self.normalizedHex(hex) else { return nil }
+        self.init(canonicalRawValue: normalized)
+    }
+
+    private init(canonicalRawValue: String) {
+        rawValue = canonicalRawValue
+    }
+
+    public var id: String { rawValue }
+    public var followsAccent: Bool { self == .multicolor }
+    public var isCustom: Bool { rawValue.hasPrefix("#") }
+    public var hexValue: String? { isCustom ? rawValue : nil }
+
+    public var color: Color {
+        switch rawValue {
+        case Self.multicolor.rawValue: return .accentColor
+        case Self.gray.rawValue: return .gray
+        case Self.red.rawValue: return .red
+        case Self.orange.rawValue: return .orange
+        case Self.yellow.rawValue: return .yellow
+        case Self.green.rawValue: return .green
+        case Self.mint.rawValue: return .mint
+        case Self.teal.rawValue: return .teal
+        case Self.cyan.rawValue: return .cyan
+        case Self.blue.rawValue: return .blue
+        case Self.indigo.rawValue: return .indigo
+        case Self.purple.rawValue: return .purple
+        case Self.pink.rawValue: return .pink
+        case Self.brown.rawValue: return .brown
+        case Self.black.rawValue: return .black
+        case Self.white.rawValue: return .white
+        default:
+            guard let components = rgbComponents else { return .accentColor }
+            return Color(.sRGB,
+                         red: Double(components.red) / 255,
+                         green: Double(components.green) / 255,
+                         blue: Double(components.blue) / 255)
+        }
+    }
+
+    public var contrastingColor: Color {
+        guard let components = rgbComponents else { return .primary }
+        let luminance = (0.299 * Double(components.red)
+                         + 0.587 * Double(components.green)
+                         + 0.114 * Double(components.blue)) / 255
+        return luminance > 0.58 ? .black : .white
+    }
+
+    public static func normalizedHex(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let digits = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard digits.count == 6, UInt32(digits, radix: 16) != nil else { return nil }
+        return "#" + digits.uppercased()
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let tint = Tint(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(in: container,
+                                                   debugDescription: "Invalid tint value: \(rawValue)")
+        }
+        self = tint
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    private var rgbComponents: (red: UInt8, green: UInt8, blue: UInt8)? {
+        guard let hexValue else { return nil }
+        let digits = hexValue.dropFirst()
+        guard let value = UInt32(digits, radix: 16) else { return nil }
+        return (UInt8((value >> 16) & 0xFF), UInt8((value >> 8) & 0xFF), UInt8(value & 0xFF))
+    }
 }
 
 enum ColorBlendMode: String, CaseIterable, Identifiable, Codable, Sendable {
@@ -123,6 +222,9 @@ enum WindowMaterial: String, CaseIterable, Identifiable, Codable, Sendable {
 }
 
 public extension EnvironmentValues {
+    /// The app-selected accent rendered by controls that need an explicit color value, such as the
+    /// "App Accent" swatch. Seed this beside `.tint(...)` at each scene root.
+    @Entry var designSystemAccentColor: Color = .accentColor
     /// The user-chosen modal material, seeded at the app root and inherited by presented sheets.
     @Entry var modalMaterial: UI.Theme.WindowMaterial = .sheet
     /// The user-chosen toolbar-control (button) material, seeded at the app root.

--- a/Packages/ContainedUI/Sources/ContainedUI/Tokens/UI.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Tokens/UI.swift
@@ -124,7 +124,12 @@ enum Tokens {
         public static let compactSlider: CGFloat = 140
         public static let networkName: CGFloat = 180
         public static let tintColorHex: CGFloat = 220
+        public static let tintSelector: CGFloat = 298
         public static let refreshReadout: CGFloat = 32
+    }
+
+    public enum TintSelector {
+        public static let trailingFadeWidth: CGFloat = 24
     }
 
     public enum Card {

--- a/Packages/ContainedUI/Tests/ContainedUITests/ThemeTintTests.swift
+++ b/Packages/ContainedUI/Tests/ContainedUITests/ThemeTintTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import ContainedUI
+
+@Suite("Theme tint")
+struct ThemeTintTests {
+    @Test func presetsMirrorTheStandardSwiftUIColorPalette() {
+        #expect(UI.Theme.Tint.allCases.map(\.rawValue) == [
+            "multicolor", "gray", "red", "orange", "yellow", "green", "mint", "teal",
+            "cyan", "blue", "indigo", "purple", "pink", "brown", "black", "white",
+        ])
+    }
+
+    @Test func legacyCuratedNamesMigrateToSystemColors() throws {
+        #expect(UI.Theme.Tint(rawValue: "graphite") == .gray)
+        #expect(UI.Theme.Tint(rawValue: "azure") == .blue)
+        #expect(UI.Theme.Tint(rawValue: "coral") == .orange)
+        #expect(UI.Theme.Tint(rawValue: "amber") == .yellow)
+        #expect(try JSONDecoder().decode(UI.Theme.Tint.self, from: Data("\"azure\"".utf8)) == .blue)
+    }
+
+    @Test func customHexNormalizesAndRoundTrips() throws {
+        let tint = try #require(UI.Theme.Tint(hex: " 7c3aed "))
+        #expect(tint.rawValue == "#7C3AED")
+        #expect(tint.isCustom)
+        #expect(UI.Theme.Tint(hex: "#12345") == nil)
+
+        let data = try JSONEncoder().encode(tint)
+        #expect(try JSONDecoder().decode(UI.Theme.Tint.self, from: data) == tint)
+    }
+}

--- a/Sources/ContainedApp/App/ContainedApp.swift
+++ b/Sources/ContainedApp/App/ContainedApp.swift
@@ -175,6 +175,9 @@ public struct ContainedApplication: App {
             MenuBarContent()
                 .environment(app)
                 .environment(ui)
+                .tint(app.settings.accentTint.resolvedAppAccentColor)
+                .accentColor(app.settings.accentTint.resolvedAppAccentColor)
+                .environment(\.designSystemAccentColor, app.settings.accentTint.resolvedAppAccentColor)
         } label: {
             Label {
                 Text("\(app.containers.running.count)")

--- a/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
@@ -646,7 +646,7 @@ private enum ContainersGridPreviewDataset {
             ]
         }
 
-        setStyle(tint: .azure, icon: "globe", nickname: "Apple web", for: appleWeb, app: app)
+        setStyle(tint: .blue, icon: "globe", nickname: "Apple web", for: appleWeb, app: app)
         setStyle(tint: .teal, icon: "shippingbox.fill", nickname: "Docker web", for: dockerWeb, app: app)
         setStyle(tint: .indigo, icon: "gearshape.2.fill", nickname: "Worker", for: worker, app: app)
         setStyle(tint: .green, icon: "cylinder.split.1x2.fill", nickname: "Database", for: db, app: app)

--- a/Sources/ContainedApp/Features/Containers/Customization/CustomizeSheet.swift
+++ b/Sources/ContainedApp/Features/Containers/Customization/CustomizeSheet.swift
@@ -186,7 +186,13 @@ struct CustomizeSheet: View {
             }
             UI.Panel.Row(title: AppText.string("customize.color", defaultValue: "Color"),
                      info: AppText.string("customize.color.info", defaultValue: "App Accent follows the accent tint from Settings; other swatches pin this style.")) {
-                UI.Control.TintSelector(selection: $style.tint) { $0.localizedDisplayName }
+                UI.Control.TintSelector(selection: $style.tint,
+                                        customLabel: AppText.customHexColor) { $0.localizedDisplayName }
+            }
+            if style.tint.isCustom {
+                UI.Panel.Row(title: AppText.customHexColor) {
+                    UI.Control.HexTintField(selection: $style.tint)
+                }
             }
         }
     }

--- a/Sources/ContainedApp/Features/Containers/Customization/CustomizeWidgetsPanel.swift
+++ b/Sources/ContainedApp/Features/Containers/Customization/CustomizeWidgetsPanel.swift
@@ -100,7 +100,13 @@ struct CustomizeWidgetsPanel: View {
         UI.Panel.ToggleRow(title: AppText.string("customize.widget.showText", defaultValue: "Show text"), isOn: widgetBinding(index, \.showText))
         UI.Panel.Row(title: AppText.string("customize.color", defaultValue: "Color")) {
             UI.Control.TintSelector(optionalSelection: widgetBinding(index, \.tint),
-                         automaticLabel: AppText.cardColor) { $0.localizedDisplayName }
+                                    automaticLabel: AppText.cardColor,
+                                    customLabel: AppText.customHexColor) { $0.localizedDisplayName }
+        }
+        if style.widget(at: index).tint?.isCustom == true {
+            UI.Panel.Row(title: AppText.customHexColor) {
+                UI.Control.HexTintField(optionalSelection: widgetBinding(index, \.tint))
+            }
         }
     }
 

--- a/Sources/ContainedApp/Features/Containers/Form/ContainerSchemaForm.swift
+++ b/Sources/ContainedApp/Features/Containers/Form/ContainerSchemaForm.swift
@@ -79,11 +79,11 @@ struct ContainerSchemaForm: View {
         HStack(spacing: UI.Layout.Spacing.xs) {
             if highlighted {
                 Circle()
-                    .fill(Color.blue)
+                    .fill(Color.accentColor)
                     .frame(width: 6, height: 6)
             }
             Text(title)
-                .foregroundStyle(highlighted ? Color.blue : Color.secondary)
+                .foregroundStyle(highlighted ? Color.accentColor : Color.secondary)
         }
     }
 
@@ -466,7 +466,13 @@ struct ContainerSchemaForm: View {
             formRow(title: AppText.string("runSpec.color", defaultValue: "Color"),
                     info: AppText.string("containerForm.personalization.color.info", defaultValue: "Sets the card icon color. If background color is enabled, it also tints the glass card."),
                     isChanged: spec.personalization.tint != Personalization().tint) {
-                UI.Control.TintSelector(selection: $spec.personalization.tint) { $0.localizedDisplayName }
+                UI.Control.TintSelector(selection: $spec.personalization.tint,
+                                        customLabel: AppText.customHexColor) { $0.localizedDisplayName }
+            }
+            if spec.personalization.tint.isCustom {
+                formRow(title: AppText.customHexColor) {
+                    UI.Control.HexTintField(selection: $spec.personalization.tint)
+                }
             }
             formToggleRow(title: AppText.string("runSpec.colorCardBackground", defaultValue: "Color the card background"),
                           info: AppText.string("containerForm.personalization.colorCardBackground.info", defaultValue: "Adds a soft color wash behind the glass. Turn it off for clear glass with only a colored icon."),

--- a/Sources/ContainedApp/Features/Settings/Tabs/AppearanceTab.swift
+++ b/Sources/ContainedApp/Features/Settings/Tabs/AppearanceTab.swift
@@ -19,7 +19,18 @@ struct AppearanceTab: View {
                 }
                 UI.Form.Row(title: AppText.string("settings.appearance.accentTint", defaultValue: "Accent tint"),
                             isChanged: settings.accentTint != .multicolor) {
-                    UI.Control.TintSelector(selection: $settings.accentTint) { $0.localizedDisplayName }
+                    UI.Control.TintSelector(selection: $settings.accentTint,
+                                            customLabel: AppText.customHexColor,
+                                            inheritedAccentColor: Platform.systemAccentColor) {
+                        $0 == .multicolor
+                            ? AppText.string("tint.systemAccent", defaultValue: "System Accent")
+                            : $0.localizedDisplayName
+                    }
+                }
+                if settings.accentTint.isCustom {
+                    UI.Form.Row(title: AppText.customHexColor) {
+                        UI.Control.HexTintField(selection: $settings.accentTint)
+                    }
                 }
             }
 
@@ -69,7 +80,13 @@ struct AppearanceTab: View {
                                   isOn: $settings.buttonTintEnabled)
                 UI.Form.Row(title: AppText.tint,
                             isChanged: settings.buttonTint != .multicolor) {
-                    UI.Control.TintSelector(selection: $settings.buttonTint) { $0.localizedDisplayName }
+                    UI.Control.TintSelector(selection: $settings.buttonTint,
+                                            customLabel: AppText.customHexColor) { $0.localizedDisplayName }
+                }
+                if settings.buttonTint.isCustom {
+                    UI.Form.Row(title: AppText.customHexColor) {
+                        UI.Control.HexTintField(selection: $settings.buttonTint)
+                    }
                 }
                 UI.Form.Row(title: AppText.string("settings.appearance.opacity", defaultValue: "Opacity"),
                             isChanged: settings.buttonTintOpacity != 0.18) {
@@ -137,7 +154,13 @@ private struct ImageDefaultStyleSection: View {
             }
             UI.Form.Row(title: AppText.string("settings.appearance.color", defaultValue: "Color"),
                         isChanged: style.tint != Personalization().tint) {
-                UI.Control.TintSelector(selection: styleBinding(\.tint)) { $0.localizedDisplayName }
+                UI.Control.TintSelector(selection: styleBinding(\.tint),
+                                        customLabel: AppText.customHexColor) { $0.localizedDisplayName }
+            }
+            if style.tint.isCustom {
+                UI.Form.Row(title: AppText.customHexColor) {
+                    UI.Control.HexTintField(selection: styleBinding(\.tint))
+                }
             }
             UI.Form.ToggleRow(title: AppText.string("settings.appearance.customIcon", defaultValue: "Custom icon"),
                               isChanged: style.iconEnabled != Personalization().iconEnabled,

--- a/Sources/ContainedApp/Features/Settings/Tabs/GeneralTab.swift
+++ b/Sources/ContainedApp/Features/Settings/Tabs/GeneralTab.swift
@@ -97,7 +97,7 @@ struct GeneralTab: View {
                 VStack(alignment: .leading, spacing: UI.Layout.Spacing.s) {
                     Text(AppText.string("settings.logging.categories", defaultValue: "Categories"))
                         .font(.caption)
-                        .foregroundStyle(settings.enabledLogCategories.count == AppLogCategory.allCases.count ? Color.secondary : Color.blue)
+                        .foregroundStyle(settings.enabledLogCategories.count == AppLogCategory.allCases.count ? Color.secondary : Color.accentColor)
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 120), alignment: .leading)],
                               alignment: .leading,
                               spacing: UI.Layout.Spacing.s) {

--- a/Sources/ContainedApp/Navigation/Shell/ClassicShell.swift
+++ b/Sources/ContainedApp/Navigation/Shell/ClassicShell.swift
@@ -106,7 +106,7 @@ private struct AppSidebar: View {
             }
         }
         .listStyle(.sidebar)
-        .tint(app.settings.accentTint.color)
+        .tint(app.settings.accentTint.resolvedAppAccentColor)
         .navigationTitle("Contained")
     }
 

--- a/Sources/ContainedApp/Navigation/Shell/RootView.swift
+++ b/Sources/ContainedApp/Navigation/Shell/RootView.swift
@@ -97,7 +97,9 @@ struct RootView: View {
         }
         .animation(reduceMotion ? nil : .smooth(duration: 0.25), value: app.banner)
         .animation(reduceMotion ? nil : .smooth(duration: 0.25), value: app.activity)
-        .tint(settings.accentTint.color)
+        .tint(settings.accentTint.resolvedAppAccentColor)
+        .accentColor(settings.accentTint.resolvedAppAccentColor)
+        .environment(\.designSystemAccentColor, settings.accentTint.resolvedAppAccentColor)
         .environment(\.modalMaterial, settings.modalMaterial)
         .environment(\.buttonMaterial, settings.buttonMaterial)
         .environment(\.buttonTintStyle, UI.Theme.ButtonTintStyle(enabled: settings.buttonTintEnabled,

--- a/Sources/ContainedApp/Navigation/Toolbar/AppToolbar.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/AppToolbar.swift
@@ -489,7 +489,7 @@ private struct ActivityToolbarButton: View {
         return UI.Action.Items([
             UI.Action.Item(systemName: hasUnread ? "bell.fill" : "bell",
                          help: hasUnread ? "Activity — \(count) unread" : "Activity",
-                         tint: hasUnread ? app.settings.accentTint.color : .white) {
+                         tint: hasUnread ? app.settings.accentTint.resolvedAppAccentColor : .white) {
                                    if ui.panelNavigationEnabled {
                                        ui.toggleMorph(.activity)
                                    } else {

--- a/Sources/ContainedApp/Presentation/Localization/AppLocalization.swift
+++ b/Sources/ContainedApp/Presentation/Localization/AppLocalization.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import ContainedCore
 import ContainedUI
 
@@ -132,6 +133,7 @@ enum AppText {
     static var sectionGroupInfra: String { string("sectionGroup.infra", defaultValue: "Infra") }
     static var sectionGroupSystem: String { string("sectionGroup.system", defaultValue: "System") }
     static var tint: String { string("common.tint", defaultValue: "Tint") }
+    static var customHexColor: String { string("common.customHexColor", defaultValue: "Custom") }
     static var unread: String { string("common.unread", defaultValue: "Unread") }
     static var runtime: String { string("runtime.label", defaultValue: "Runtime") }
     static var runtimeSubtitle: String {
@@ -618,23 +620,37 @@ enum AppText {
 }
 
 extension UI.Theme.Tint {
+    /// Resolves the app-level inheritance choice to the native macOS accent before the app scopes
+    /// that value back into SwiftUI's tint and accent environments.
+    @MainActor var resolvedAppAccentColor: Color {
+        self == .multicolor ? Platform.systemAccentColor : color
+    }
+
     var localizedDisplayName: String {
-        switch self {
-        case .multicolor: return AppText.string("tint.multicolor", defaultValue: "App Accent")
-        case .graphite: return AppText.string("tint.graphite", defaultValue: "Graphite")
-        case .azure: return AppText.string("tint.azure", defaultValue: "Azure")
-        case .teal: return AppText.string("tint.teal", defaultValue: "Teal")
-        case .coral: return AppText.string("tint.coral", defaultValue: "Coral")
-        case .indigo: return AppText.string("tint.indigo", defaultValue: "Indigo")
-        case .green: return AppText.string("tint.green", defaultValue: "Green")
-        case .amber: return AppText.string("tint.amber", defaultValue: "Amber")
-        case .pink: return AppText.string("tint.pink", defaultValue: "Pink")
+        switch rawValue {
+        case UI.Theme.Tint.multicolor.rawValue: return AppText.string("tint.multicolor", defaultValue: "App Accent")
+        case UI.Theme.Tint.gray.rawValue: return AppText.string("tint.gray", defaultValue: "Gray")
+        case UI.Theme.Tint.red.rawValue: return AppText.string("tint.red", defaultValue: "Red")
+        case UI.Theme.Tint.orange.rawValue: return AppText.string("tint.orange", defaultValue: "Orange")
+        case UI.Theme.Tint.yellow.rawValue: return AppText.string("tint.yellow", defaultValue: "Yellow")
+        case UI.Theme.Tint.green.rawValue: return AppText.string("tint.green", defaultValue: "Green")
+        case UI.Theme.Tint.mint.rawValue: return AppText.string("tint.mint", defaultValue: "Mint")
+        case UI.Theme.Tint.teal.rawValue: return AppText.string("tint.teal", defaultValue: "Teal")
+        case UI.Theme.Tint.cyan.rawValue: return AppText.string("tint.cyan", defaultValue: "Cyan")
+        case UI.Theme.Tint.blue.rawValue: return AppText.string("tint.blue", defaultValue: "Blue")
+        case UI.Theme.Tint.indigo.rawValue: return AppText.string("tint.indigo", defaultValue: "Indigo")
+        case UI.Theme.Tint.purple.rawValue: return AppText.string("tint.purple", defaultValue: "Purple")
+        case UI.Theme.Tint.pink.rawValue: return AppText.string("tint.pink", defaultValue: "Pink")
+        case UI.Theme.Tint.brown.rawValue: return AppText.string("tint.brown", defaultValue: "Brown")
+        case UI.Theme.Tint.black.rawValue: return AppText.string("tint.black", defaultValue: "Black")
+        case UI.Theme.Tint.white.rawValue: return AppText.string("tint.white", defaultValue: "White")
+        default: return rawValue
         }
     }
 
     var localizedSearchAliases: [String] {
-        switch self {
-        case .multicolor:
+        switch rawValue {
+        case UI.Theme.Tint.multicolor.rawValue:
             return [
                 AppText.string("tint.multicolor.alias.default", defaultValue: "default"),
                 AppText.string("tint.multicolor.alias.appAccent", defaultValue: "app accent"),
@@ -642,47 +658,40 @@ extension UI.Theme.Tint {
                 AppText.string("tint.multicolor.alias.auto", defaultValue: "auto"),
                 AppText.string("tint.multicolor.alias.rainbow", defaultValue: "rainbow"),
             ]
-        case .graphite:
+        case UI.Theme.Tint.gray.rawValue:
             return [
-                AppText.string("tint.graphite.alias.gray", defaultValue: "gray"),
-                AppText.string("tint.graphite.alias.grey", defaultValue: "grey"),
-                AppText.string("tint.graphite.alias.slate", defaultValue: "slate"),
-                AppText.string("tint.graphite.alias.charcoal", defaultValue: "charcoal"),
-                AppText.string("tint.graphite.alias.silver", defaultValue: "silver"),
-                AppText.string("tint.graphite.alias.neutral", defaultValue: "neutral"),
-                AppText.string("tint.graphite.alias.mono", defaultValue: "mono"),
+                AppText.string("tint.gray.alias.grey", defaultValue: "grey"),
+                AppText.string("tint.gray.alias.graphite", defaultValue: "graphite"),
+                AppText.string("tint.gray.alias.slate", defaultValue: "slate"),
+                AppText.string("tint.gray.alias.charcoal", defaultValue: "charcoal"),
+                AppText.string("tint.gray.alias.silver", defaultValue: "silver"),
             ]
-        case .azure:
+        case UI.Theme.Tint.blue.rawValue:
             return [
-                AppText.string("tint.azure.alias.blue", defaultValue: "blue"),
-                AppText.string("tint.azure.alias.sky", defaultValue: "sky"),
-                AppText.string("tint.azure.alias.ocean", defaultValue: "ocean"),
-                AppText.string("tint.azure.alias.cobalt", defaultValue: "cobalt"),
+                AppText.string("tint.blue.alias.azure", defaultValue: "azure"),
+                AppText.string("tint.blue.alias.sky", defaultValue: "sky"),
+                AppText.string("tint.blue.alias.ocean", defaultValue: "ocean"),
+                AppText.string("tint.blue.alias.cobalt", defaultValue: "cobalt"),
             ]
-        case .teal:
+        case UI.Theme.Tint.teal.rawValue:
             return [
-                AppText.string("tint.teal.alias.cyan", defaultValue: "cyan"),
                 AppText.string("tint.teal.alias.aqua", defaultValue: "aqua"),
                 AppText.string("tint.teal.alias.turquoise", defaultValue: "turquoise"),
-                AppText.string("tint.teal.alias.mint", defaultValue: "mint"),
                 AppText.string("tint.teal.alias.seafoam", defaultValue: "seafoam"),
             ]
-        case .coral:
+        case UI.Theme.Tint.orange.rawValue:
             return [
-                AppText.string("tint.coral.alias.orange", defaultValue: "orange"),
-                AppText.string("tint.coral.alias.salmon", defaultValue: "salmon"),
-                AppText.string("tint.coral.alias.burnt", defaultValue: "burnt"),
-                AppText.string("tint.coral.alias.terracotta", defaultValue: "terracotta"),
-                AppText.string("tint.coral.alias.rust", defaultValue: "rust"),
+                AppText.string("tint.orange.alias.coral", defaultValue: "coral"),
+                AppText.string("tint.orange.alias.salmon", defaultValue: "salmon"),
+                AppText.string("tint.orange.alias.rust", defaultValue: "rust"),
             ]
-        case .indigo:
+        case UI.Theme.Tint.indigo.rawValue:
             return [
-                AppText.string("tint.indigo.alias.purple", defaultValue: "purple"),
                 AppText.string("tint.indigo.alias.violet", defaultValue: "violet"),
                 AppText.string("tint.indigo.alias.blurple", defaultValue: "blurple"),
                 AppText.string("tint.indigo.alias.royal", defaultValue: "royal"),
             ]
-        case .green:
+        case UI.Theme.Tint.green.rawValue:
             return [
                 AppText.string("tint.green.alias.lime", defaultValue: "lime"),
                 AppText.string("tint.green.alias.olive", defaultValue: "olive"),
@@ -690,14 +699,13 @@ extension UI.Theme.Tint {
                 AppText.string("tint.green.alias.forest", defaultValue: "forest"),
                 AppText.string("tint.green.alias.moss", defaultValue: "moss"),
             ]
-        case .amber:
+        case UI.Theme.Tint.yellow.rawValue:
             return [
-                AppText.string("tint.amber.alias.yellow", defaultValue: "yellow"),
-                AppText.string("tint.amber.alias.gold", defaultValue: "gold"),
-                AppText.string("tint.amber.alias.honey", defaultValue: "honey"),
-                AppText.string("tint.amber.alias.mustard", defaultValue: "mustard"),
+                AppText.string("tint.yellow.alias.amber", defaultValue: "amber"),
+                AppText.string("tint.yellow.alias.gold", defaultValue: "gold"),
+                AppText.string("tint.yellow.alias.honey", defaultValue: "honey"),
             ]
-        case .pink:
+        case UI.Theme.Tint.pink.rawValue:
             return [
                 AppText.string("tint.pink.alias.magenta", defaultValue: "magenta"),
                 AppText.string("tint.pink.alias.rose", defaultValue: "rose"),
@@ -705,6 +713,22 @@ extension UI.Theme.Tint {
                 AppText.string("tint.pink.alias.crimson", defaultValue: "crimson"),
                 AppText.string("tint.pink.alias.hotPink", defaultValue: "hot pink"),
             ]
+        case UI.Theme.Tint.red.rawValue:
+            return [AppText.string("tint.red.alias.crimson", defaultValue: "crimson")]
+        case UI.Theme.Tint.mint.rawValue:
+            return [AppText.string("tint.mint.alias.seafoam", defaultValue: "seafoam")]
+        case UI.Theme.Tint.cyan.rawValue:
+            return [AppText.string("tint.cyan.alias.aqua", defaultValue: "aqua")]
+        case UI.Theme.Tint.purple.rawValue:
+            return [AppText.string("tint.purple.alias.violet", defaultValue: "violet")]
+        case UI.Theme.Tint.brown.rawValue:
+            return [AppText.string("tint.brown.alias.earth", defaultValue: "earth")]
+        case UI.Theme.Tint.black.rawValue:
+            return [AppText.string("tint.black.alias.dark", defaultValue: "dark")]
+        case UI.Theme.Tint.white.rawValue:
+            return [AppText.string("tint.white.alias.light", defaultValue: "light")]
+        default:
+            return [localizedDisplayName.lowercased()]
         }
     }
 }

--- a/Sources/ContainedApp/Services/Platform/Platform.swift
+++ b/Sources/ContainedApp/Services/Platform/Platform.swift
@@ -1,8 +1,13 @@
 import AppKit
+import SwiftUI
 
 /// Narrow AppKit boundary for macOS host behaviors SwiftUI does not expose directly.
 @MainActor
 enum Platform {
+    static var systemAccentColor: Color {
+        Color(nsColor: .controlAccentColor)
+    }
+
     static func disableAutomaticWindowTabbing() {
         NSWindow.allowsAutomaticWindowTabbing = false
     }

--- a/Tests/ContainedAppTests/PreviewFixtureMappingTests.swift
+++ b/Tests/ContainedAppTests/PreviewFixtureMappingTests.swift
@@ -21,13 +21,13 @@ private extension Personalization {
         var style = Personalization()
         style.nickname = snapshot.displayName
         style.icon = "shippingbox.fill"
-        style.tint = .azure
+        style.tint = .blue
         style.fillBackground = true
         style.backgroundOpacity = 0.16
         style.gradient = true
         style.widgets = [
             WidgetConfiguration(metric: .cpu,
-                                tint: .azure,
+                                tint: .blue,
                                 icon: "cpu",
                                 style: .area,
                                 showText: true),


### PR DESCRIPTION
## What changed

- expands tint customization to SwiftUI’s standard Apple colors plus custom `#RRGGBB` values
- makes the selected app accent scope native controls and explicit accent-colored UI throughout the main and menu-bar scenes
- gives the app-accent picker native macOS inheritance while other pickers inherit the app accent
- makes shared form and panel rows responsive without clipping important labels
- preserves image and image-group customization when refreshed image identity changes

## Why

The previous curated palette was limited, explicit `Color.accentColor` drawing continued to render with the system blue, narrow rows could truncate labels, and digest-based image identity stranded saved customization after pulls.

## User impact

Color selection is more flexible and consistent, panel page switches and other accent chrome follow the chosen app color, custom hex input appears only when selected, responsive forms retain their labels, and image customization survives updates.

## Validation

- `swift build`
- `swift test --quiet` (122 tests)
- `swift test --quiet` in `Packages/ContainedUI` (16 tests)
- `xcodebuild -workspace Contained.xcworkspace -scheme Contained -configuration Debug build -quiet`
- `./Scripts/check.sh repo`
- `git diff --check`
- `./Scripts/build.sh run --verify`
