### PR TITLE
Improve container card customization

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Container cards now infer a browser shortcut from their first published TCP port, with an optional per-container URL override for hosts and paths. Appearance inheritance now covers only icon, tint, and background; nickname, URL, status, and widgets remain container-specific. Available updates stay visible as the far-right footer action.
+- Image, tag, and container nicknames now stay scoped to the resource being customized. Image and tag names compose in card references (for example, `nice-image:latest`) without nickname-only changes disabling inherited appearance.

--- a/Documentation/Features/Containers.md
+++ b/Documentation/Features/Containers.md
@@ -7,9 +7,16 @@ available, the grid aggregates containers from every reachable runtime.
 
 - Personalized Liquid Glass cards show status, image, command, resource
   highlights, and local-only appearance choices.
-- Card personalization can be set per container or inherited from image styling.
-- Local tint, nickname, icon, and card background are not written back to
-  container labels.
+- Card appearance (icon, tint, and background) can be set per container or
+  inherited from image styling. Container-only choices such as nickname, web
+  destination, status display, and widgets remain independently editable.
+- Image, tag, and container nicknames are separate identities. Cards compose
+  image and tag nicknames into compact references such as `nice-image:latest`,
+  while a container keeps its own title.
+- Local personalization is not written back to container labels.
+- A card shows an **Open in browser** action when the container publishes a TCP
+  port. Customize can supply a full URL or host/path override; otherwise the
+  first published port opens on localhost.
 - Cards expose full-card hit targets plus context actions for lifecycle and edit
   operations.
 
@@ -30,7 +37,8 @@ owning runtime:
 Rebuild is always available from a container's context menu. When the app knows
 that the container's immutable image identity differs from the current tag—or a
 newer registry digest is available—the action is relabeled **Update Container**
-and an orange update button appears in the card footer. Updating pulls first only
+and an orange update button appears persistently at the far right of the card
+footer. Updating pulls first only
 when needed, then recreates through the same rollback path as Edit → Save.
 Rebuild and Update preserve whether the container was running or stopped, while
 ordinary Start, Stop, and Restart remain non-destructive lifecycle operations.

--- a/Packages/ContainedUI/Sources/ContainedUI/Card/Card+Scaffold.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Card/Card+Scaffold.swift
@@ -73,6 +73,7 @@ struct Scaffold<Icon: View, TitleAccessory: View, SubtitleAccessory: View,
     @ViewBuilder public var footerLeading: () -> FooterLeading
     @ViewBuilder public var footerActions: () -> FooterActions
     @ViewBuilder public var widget: () -> Widget
+    public var persistentFooterActions: AnyView?
 
     private var usesSelectionFill = false
 
@@ -90,6 +91,7 @@ struct Scaffold<Icon: View, TitleAccessory: View, SubtitleAccessory: View,
                 blendMode: UI.Theme.ColorBlendMode = .softLight,
                 elevated: Bool = true,
                 onTap: @escaping () -> Void = {},
+                persistentFooterActions: AnyView? = nil,
                 title: String,
                 subtitle: String? = nil,
                 titleStyle: UI.Card.TextStyle = .standard,
@@ -117,6 +119,7 @@ struct Scaffold<Icon: View, TitleAccessory: View, SubtitleAccessory: View,
         self.blendMode = blendMode
         self.elevated = elevated
         self.onTap = onTap
+        self.persistentFooterActions = persistentFooterActions
         self.title = title
         self.subtitle = subtitle
         self.titleStyle = titleStyle
@@ -152,7 +155,8 @@ struct Scaffold<Icon: View, TitleAccessory: View, SubtitleAccessory: View,
                           gradientAngle: gradientAngle,
                           blendMode: blendMode,
                           elevated: elevated,
-                          onTap: onTap) {
+                          onTap: onTap,
+                          persistentFooterActions: persistentFooterActions) {
             header
         } bodyContent: {
             bodyContent()
@@ -242,6 +246,7 @@ public extension UI.Card.Scaffold where PageID == UI.Card.NoPage {
          blendMode: UI.Theme.ColorBlendMode = .softLight,
          elevated: Bool = true,
          onTap: @escaping () -> Void = {},
+         persistentFooterActions: AnyView? = nil,
          title: String,
          subtitle: String? = nil,
          titleStyle: UI.Card.TextStyle = .standard,
@@ -268,6 +273,7 @@ public extension UI.Card.Scaffold where PageID == UI.Card.NoPage {
                   blendMode: blendMode,
                   elevated: elevated,
                   onTap: onTap,
+                  persistentFooterActions: persistentFooterActions,
                   title: title,
                   subtitle: subtitle,
                   titleStyle: titleStyle,

--- a/Packages/ContainedUI/Sources/ContainedUI/Card/Chrome.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Card/Chrome.swift
@@ -340,6 +340,7 @@ struct CardFooter<Leading: View, Trailing: View, Widget: View>: View {
     @ViewBuilder var leading: () -> Leading
     @ViewBuilder var trailing: () -> Trailing
     @ViewBuilder var widget: () -> Widget
+    var persistentTrailing: AnyView?
 
     init(showWidget: Bool = false,
          actionsVisible: Bool = true,
@@ -347,6 +348,7 @@ struct CardFooter<Leading: View, Trailing: View, Widget: View>: View {
          horizontalPadding: CGFloat = UI.Tokens.Card.padding,
          topPadding: CGFloat = 0,
          bottomPadding: CGFloat = UI.Tokens.Card.padding,
+         persistentTrailing: AnyView? = nil,
          @ViewBuilder leading: @escaping () -> Leading,
          @ViewBuilder trailing: @escaping () -> Trailing,
          @ViewBuilder widget: @escaping () -> Widget) {
@@ -356,6 +358,7 @@ struct CardFooter<Leading: View, Trailing: View, Widget: View>: View {
         self.horizontalPadding = horizontalPadding
         self.topPadding = topPadding
         self.bottomPadding = bottomPadding
+        self.persistentTrailing = persistentTrailing
         self.leading = leading
         self.trailing = trailing
         self.widget = widget
@@ -376,6 +379,9 @@ struct CardFooter<Leading: View, Trailing: View, Widget: View>: View {
                 .opacity(actionsVisible ? 1 : 0)
                 .allowsHitTesting(actionsVisible)
                 .animation(.easeOut(duration: 0.18), value: actionsVisible)
+                if let persistentTrailing {
+                    persistentTrailing
+                }
             }
             .padding(.horizontal, horizontalPadding)
             .padding(.top, topPadding)

--- a/Packages/ContainedUI/Sources/ContainedUI/Card/Surface.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Card/Surface.swift
@@ -71,6 +71,7 @@ struct CardSurface<Header: View, BodyContent: View, FooterLeading: View,
     @ViewBuilder var footerLeading: () -> FooterLeading
     @ViewBuilder var footerActions: () -> FooterActions
     @ViewBuilder var widget: () -> Widget
+    var persistentFooterActions: AnyView?
 
     @State private var hovering = false
     @Environment(\.cardMaterial) private var cardMaterial
@@ -96,6 +97,7 @@ struct CardSurface<Header: View, BodyContent: View, FooterLeading: View,
          blendMode: UI.Theme.ColorBlendMode = .softLight,
          elevated: Bool = true,
          onTap: @escaping () -> Void = {},
+         persistentFooterActions: AnyView? = nil,
          @ViewBuilder header: @escaping () -> Header,
          @ViewBuilder bodyContent: @escaping () -> BodyContent,
          @ViewBuilder footerLeading: @escaping () -> FooterLeading,
@@ -115,6 +117,7 @@ struct CardSurface<Header: View, BodyContent: View, FooterLeading: View,
         self.blendMode = blendMode
         self.elevated = elevated
         self.onTap = onTap
+        self.persistentFooterActions = persistentFooterActions
         self.header = header
         self.bodyContent = bodyContent
         self.footerLeading = footerLeading
@@ -209,7 +212,8 @@ struct CardSurface<Header: View, BodyContent: View, FooterLeading: View,
     }
 
     private func stickyFooter(showActions: Bool) -> some View {
-        UI.Card.CardFooter(actionsVisible: showActions) {
+        UI.Card.CardFooter(actionsVisible: showActions,
+                           persistentTrailing: persistentFooterActions) {
             footerLeading()
         } trailing: {
             footerActions()
@@ -246,7 +250,9 @@ struct CardSurface<Header: View, BodyContent: View, FooterLeading: View,
     }
 
     private var hasFooterSlot: Bool {
-        FooterLeading.self != EmptyView.self || FooterActions.self != EmptyView.self
+        FooterLeading.self != EmptyView.self
+            || FooterActions.self != EmptyView.self
+            || persistentFooterActions != nil
     }
 }
 

--- a/Sources/ContainedApp/App/AppModel+ResourceStyles.swift
+++ b/Sources/ContainedApp/App/AppModel+ResourceStyles.swift
@@ -16,19 +16,64 @@ extension AppModel {
     }
 
     func imageStyle(for reference: String) -> Personalization {
-        personalization.imageDefault(for: reference, group: localImageGroup(containing: reference)) ?? defaultImageStyle
+        let group = localImageGroup(containing: reference)
+        var style = personalization.resolvedImageAppearance(for: reference,
+                                                             group: group,
+                                                             fallback: defaultImageStyle)
+        style.nickname = personalization.imageDefault(for: reference)?.nickname ?? ""
+        return style
     }
 
     func imageGroupStyle(for group: Core.Image.LocalTagGroup) -> Personalization {
-        personalization.imageGroupDefault(for: group) ?? defaultImageStyle
+        let own = personalization.imageGroupDefault(for: group)
+        var style = defaultImageStyle.appearanceOnly()
+        if let own, own.hasAppearanceCustomization { style = own }
+        style.nickname = own?.nickname ?? ""
+        return style
     }
 
     /// The group's style by id, used where only the id is known, such as a tag resolving its parent.
     func imageGroupStyle(forID id: String) -> Personalization {
         if let group = localImageGroup(id: id) {
-            return personalization.imageGroupDefault(for: group) ?? defaultImageStyle
+            return imageGroupStyle(for: group)
         }
-        return personalization.imageGroupDefault(forLegacyID: id) ?? defaultImageStyle
+        let own = personalization.imageGroupDefault(forLegacyID: id)
+        var style = defaultImageStyle.appearanceOnly()
+        if let own, own.hasAppearanceCustomization { style = own }
+        style.nickname = own?.nickname ?? ""
+        return style
+    }
+
+    func imageDisplayName(for reference: String) -> String {
+        let parsed = Core.Registry.ImageReference.parse(reference)
+        let groupNickname = localImageGroup(containing: reference)
+            .flatMap { personalization.imageGroupDefault(for: $0)?.nickname }
+            .flatMap(Self.nonEmptyNickname)
+        let savedTagNickname = personalization.imageDefault(for: reference)?.nickname
+        let tagNickname = savedTagNickname.flatMap(Self.nonEmptyNickname)
+        guard groupNickname != nil || tagNickname != nil else { return Format.shortImage(reference) }
+
+        let separator = parsed.isDigestReference ? "@" : ":"
+        let repository = groupNickname ?? Self.repositoryDisplayName(from: reference, parsed: parsed)
+        return "\(repository)\(separator)\(tagNickname ?? parsed.reference)"
+    }
+
+    func imageGroupDisplayName(for group: Core.Image.LocalTagGroup) -> String? {
+        let savedNickname = personalization.imageGroupDefault(for: group)?.nickname
+        return savedNickname.flatMap(Self.nonEmptyNickname)
+    }
+
+    private static func nonEmptyNickname(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func repositoryDisplayName(from reference: String,
+                                              parsed: Core.Registry.ImageReference) -> String {
+        let short = Format.shortImage(reference)
+        let separator = parsed.isDigestReference ? "@" : ":"
+        let suffix = "\(separator)\(parsed.reference)"
+        return short.hasSuffix(suffix) ? String(short.dropLast(suffix.count)) : short
     }
 
     func volumeStyle(for name: String) -> Personalization {

--- a/Sources/ContainedApp/Features/Containers/Card/ContainerCard.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainerCard.swift
@@ -5,6 +5,9 @@ import ContainedCore
 /// A personalized clear-glass card for one container. The same component renders both the compact
 /// grid card and the centered expanded detail card.
 struct ContainerCard: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.openURL) private var openURL
+
     let snapshot: Core.Container.Snapshot
     var style: Personalization
     var hasStyleOverride: Bool = true
@@ -87,6 +90,9 @@ struct ContainerCard: View {
                                                    options: Core.Metrics.GraphMetric.allCases)
     }
     private var cardSize: UI.Card.Size { density.resourceSize }
+    private var webDestination: URL? {
+        ContainerWebDestination.url(customValue: styleForDisplay.webURL, for: snapshot)
+    }
 
     var body: some View {
         Group {
@@ -139,8 +145,9 @@ struct ContainerCard: View {
                      gradientAngle: styleForDisplay.gradientAngle,
                      blendMode: styleForDisplay.backgroundBlendMode,
                      onTap: onTap,
+                     persistentFooterActions: persistentFooterActions,
                      title: name,
-                     subtitle: Format.shortImage(snapshot.image),
+                     subtitle: app.imageDisplayName(for: snapshot.image),
                      subtitleStyle: .monospaced,
                      // Compact cards never expose page controls. Keeping this nil also avoids
                      // constructing all detail-page buttons for every card in a large grid.
@@ -280,6 +287,11 @@ struct ContainerCard: View {
         }
         Divider()
         Button { onTap() } label: { Label("Open details", systemImage: "rectangle.expand.vertical") }
+        if let webDestination {
+            Button { openURL(webDestination) } label: {
+                Label("Open in browser", systemImage: "arrow.up.right.square")
+            }
+        }
         if selecting {
             Button { onToggleSelected() } label: {
                 Label(isSelected ? "Deselect" : "Select", systemImage: isSelected ? "checkmark.circle.fill" : "circle")
@@ -391,13 +403,22 @@ struct ContainerCard: View {
             footerAction("play.fill", help: AppText.start, tint: tint, action: onStart)
         }
         footerAction("slider.horizontal.3", help: AppText.edit, action: onEdit)
-        if imageUpdateState.requiresUpdate {
+        if let webDestination {
+            footerAction("arrow.up.right.square", help: "Open in browser") {
+                openURL(webDestination)
+            }
+        }
+        footerAction("trash", help: AppText.delete, role: .destructive) { confirmingDelete = true }
+    }
+
+    private var persistentFooterActions: AnyView? {
+        guard imageUpdateState.requiresUpdate else { return nil }
+        return AnyView(
             footerAction("arrow.down.circle",
                          help: AppText.updateContainer,
                          tint: .orange,
                          action: onRebuild)
-        }
-        footerAction("trash", help: AppText.delete, role: .destructive) { confirmingDelete = true }
+        )
     }
 
     private func footerAction(_ systemName: String, help: String, tint: Color? = nil,

--- a/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
@@ -315,7 +315,7 @@ struct ContainersGridView: View {
                                onTap: @escaping () -> Void) -> some View {
         let style = app.containerStyle(for: snapshot)
         let key = snapshot.scopedID
-        let hasStyleOverride = app.personalization.hasOverride(id: key)
+        let hasStyleOverride = app.personalization.hasAppearanceOverride(id: key)
         let imageUpdateState = app.containerImageUpdateState(for: snapshot)
         return ContainerCardMetricsRenderer(
             metrics: store.metricsState(for: key),

--- a/Sources/ContainedApp/Features/Containers/ContainerWebDestination.swift
+++ b/Sources/ContainedApp/Features/Containers/ContainerWebDestination.swift
@@ -1,0 +1,41 @@
+import Foundation
+import ContainedCore
+
+/// Resolves the local web destination shown by a container card.
+enum ContainerWebDestination {
+    static func url(customValue: String, for snapshot: Core.Container.Snapshot) -> URL? {
+        normalizedCustomURL(customValue) ?? inferredURL(for: snapshot)
+    }
+
+    static func inferredURL(for snapshot: Core.Container.Snapshot) -> URL? {
+        guard let port = snapshot.configuration.publishedPorts.first(where: {
+            ($0.proto ?? "tcp").lowercased() == "tcp" && $0.hostPort > 0
+        }) else { return nil }
+
+        var components = URLComponents()
+        components.scheme = port.hostPort == 443 ? "https" : "http"
+        components.host = browserHost(port.hostAddress)
+        components.port = port.hostPort
+        return components.url
+    }
+
+    private static func normalizedCustomURL(_ value: String) -> URL? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let candidate = trimmed.contains("://") ? trimmed : "http://\(trimmed)"
+        guard let components = URLComponents(string: candidate),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              components.host?.isEmpty == false else { return nil }
+        return components.url
+    }
+
+    private static func browserHost(_ hostAddress: String?) -> String {
+        guard let hostAddress,
+              !hostAddress.isEmpty,
+              hostAddress != "0.0.0.0",
+              hostAddress != "::",
+              hostAddress != "[::]" else { return "localhost" }
+        return hostAddress
+    }
+}

--- a/Sources/ContainedApp/Features/Containers/Customization/CustomizeSheet.swift
+++ b/Sources/ContainedApp/Features/Containers/Customization/CustomizeSheet.swift
@@ -126,16 +126,16 @@ struct CustomizeSheet: View {
             ScrollView {
                 LazyVStack(spacing: UI.Layout.Spacing.l) {
                     if target.supportsInheritance { inheritanceSection }
-                    editableSection { styleSection }
+                    editableSection { appearanceSection }
                     if case .container = target {
-                        editableSection { statusSection }
+                        containerSection
+                    } else {
+                        identitySection
                     }
                     if !target.isImage {
                         CustomizeWidgetsPanel(style: $style,
-                                              graphOptions: graphOptions,
-                                              settingsDisabled: settingsDisabled)
+                                              graphOptions: graphOptions)
                     }
-                    editableSection { backgroundSection }
                     actionsSection
                 }
                 .padding(.horizontal, UI.Layout.Spacing.l)
@@ -168,12 +168,8 @@ struct CustomizeSheet: View {
         }
     }
 
-    private var styleSection: some View {
-        UI.Panel.Section(header: AppText.string("customize.style", defaultValue: "Style")) {
-            UI.Panel.Field(label: nicknameLabel) {
-                TextField("", text: $style.nickname, prompt: Text(nicknamePrompt))
-                    .textFieldStyle(.roundedBorder)
-            }
+    private var appearanceSection: some View {
+        UI.Panel.Section(header: AppText.string("customize.appearance", defaultValue: "Appearance")) {
             UI.Panel.ToggleRow(title: AppText.string("customize.customIcon", defaultValue: "Custom icon"), isOn: $style.iconEnabled)
             if style.iconEnabled {
                 UI.Panel.Field(label: AppText.string("customize.icon", defaultValue: "Icon")) {
@@ -194,21 +190,7 @@ struct CustomizeSheet: View {
                     UI.Control.HexTintField(selection: $style.tint)
                 }
             }
-        }
-    }
-
-    private var statusSection: some View {
-        UI.Panel.Section(header: AppText.string("customize.status", defaultValue: "Status")) {
-            UI.Panel.ToggleRow(title: AppText.string("customize.showStatusIndicator", defaultValue: "Show status indicator"), isOn: $style.showStatusIndicator)
-            if style.showStatusIndicator {
-                UI.Panel.ToggleRow(title: AppText.string("customize.widget.showIcon", defaultValue: "Show icon"), isOn: $style.showStatusIcon)
-                UI.Panel.ToggleRow(title: AppText.string("customize.widget.showText", defaultValue: "Show text"), isOn: $style.showStatusText)
-            }
-        }
-    }
-
-    private var backgroundSection: some View {
-        UI.Panel.Section(header: AppText.string("customize.background", defaultValue: "Background")) {
+            Divider()
             UI.Panel.ToggleRow(title: AppText.string("customize.colorCardBackground", defaultValue: "Color the card background"), isOn: $style.fillBackground)
             if style.fillBackground {
                 UI.Panel.Row(title: AppText.string("customize.opacity", defaultValue: "Opacity")) {
@@ -232,6 +214,35 @@ struct CustomizeSheet: View {
                     .labelsHidden()
                     .fixedSize()
                 }
+            }
+        }
+    }
+
+    private var identitySection: some View {
+        UI.Panel.Section(header: AppText.string("customize.identity", defaultValue: "Identity")) {
+            UI.Panel.Field(label: nicknameLabel) {
+                TextField("", text: $style.nickname, prompt: Text(nicknamePrompt))
+                    .textFieldStyle(.roundedBorder)
+            }
+        }
+    }
+
+    private var containerSection: some View {
+        UI.Panel.Section(header: AppText.string("customize.container", defaultValue: "Container")) {
+            UI.Panel.Field(label: nicknameLabel) {
+                TextField("", text: $style.nickname, prompt: Text(nicknamePrompt))
+                    .textFieldStyle(.roundedBorder)
+            }
+            UI.Panel.Row(title: AppText.string("customize.openURL", defaultValue: "Open URL"),
+                         subtitle: automaticURLSubtitle) {
+                TextField("", text: $style.webURL, prompt: Text("http://localhost:8080/path"))
+                    .textFieldStyle(.roundedBorder)
+            }
+            Divider()
+            UI.Panel.ToggleRow(title: AppText.string("customize.showStatusIndicator", defaultValue: "Show status indicator"), isOn: $style.showStatusIndicator)
+            if style.showStatusIndicator {
+                UI.Panel.ToggleRow(title: AppText.string("customize.widget.showIcon", defaultValue: "Show icon"), isOn: $style.showStatusIcon)
+                UI.Panel.ToggleRow(title: AppText.string("customize.widget.showText", defaultValue: "Show text"), isOn: $style.showStatusText)
             }
         }
     }
@@ -267,6 +278,16 @@ struct CustomizeSheet: View {
         return Core.Metrics.GraphMetric.allCases
     }
 
+    private var automaticURLSubtitle: String? {
+        guard case .container(let snapshot) = target else { return nil }
+        if let inferred = ContainerWebDestination.inferredURL(for: snapshot) {
+            return AppText.string("customize.openURL.portFallback",
+                                  defaultValue: "Leave blank to use \(inferred.absoluteString).")
+        }
+        return AppText.string("customize.openURL.optional",
+                              defaultValue: "Optional. Add a web address to show an Open button.")
+    }
+
     private var headerTitle: String {
         switch target {
         case .container: return AppText.string("customize.header.card", defaultValue: "Customize card")
@@ -287,28 +308,39 @@ struct CustomizeSheet: View {
     private var overrideToggleHint: String {
         switch target {
         case .container:
-            return AppText.string("customize.override.containerHint", defaultValue: "Turn this on to customize only this container. Leave it off to inherit the image style.")
+            return AppText.string("customize.override.containerHint", defaultValue: "Turn this on to customize this container's appearance. Its nickname, URL, status, and widgets remain independent.")
         case .image:
-            return AppText.string("customize.override.imageHint", defaultValue: "Turn this on to style containers from this exact image. Leave it off to inherit the Settings default.")
+            return AppText.string("customize.override.imageHint", defaultValue: "Turn this on to override appearance. The image nickname remains independent.")
         case .imageGroup:
-            return AppText.string("customize.override.imageGroupHint", defaultValue: "Turn this on to style this image group. Leave it off to inherit the Settings default.")
+            return AppText.string("customize.override.imageGroupHint", defaultValue: "Turn this on to override appearance. The image nickname remains independent.")
         case .imageTag:
-            return AppText.string("customize.override.imageTagHint", defaultValue: "Turn this on to style only this tag. Leave it off to inherit the image group's style.")
+            return AppText.string("customize.override.imageTagHint", defaultValue: "Turn this on to override appearance. The tag nickname remains independent.")
         case .volume:
             return ""
         }
     }
 
     private var nicknameLabel: String {
-        if case .container = target { return AppText.string("customize.nickname", defaultValue: "Nickname") }
-        return AppText.string("customize.displayName", defaultValue: "Display name")
+        switch target {
+        case .container: return AppText.string("customize.nickname.container", defaultValue: "Container nickname")
+        case .image, .imageGroup: return AppText.string("customize.nickname.image", defaultValue: "Image nickname")
+        case .imageTag: return AppText.string("customize.nickname.tag", defaultValue: "Tag nickname")
+        case .volume: return AppText.string("customize.nickname.volume", defaultValue: "Volume nickname")
+        }
     }
 
     private var nicknamePrompt: String {
         switch target {
         case .container: return target.previewSnapshot.id
         case .volume(let name): return name
-        default: return Format.shortImage(target.image)
+        case .imageTag(let reference, _):
+            return Core.Registry.ImageReference.parse(reference).reference
+        case .image(let reference):
+            return Core.Registry.ImageReference.parse(reference).repository.split(separator: "/").last.map(String.init)
+                ?? Format.shortImage(reference)
+        case .imageGroup(let group):
+            return Core.Registry.ImageReference.parse(group.primaryReference).repository.split(separator: "/").last.map(String.init)
+                ?? Format.shortImage(group.primaryReference)
         }
     }
 
@@ -358,7 +390,10 @@ struct CustomizeSheet: View {
             overridesInheritedStyle = newValue
             switch target {
             case .container, .image, .imageGroup, .imageTag:
-                style = newValue ? ownStyle() : inheritedStyle()
+                var updated = style
+                updated.applyAppearance(from: newValue ? ownStyle() : inheritedStyle())
+                updated.appearanceOverrideEnabled = newValue
+                style = updated
             case .volume:
                 break
             }
@@ -370,19 +405,16 @@ struct CustomizeSheet: View {
         switch target {
         case .container(let snapshot):
             style = app.containerStyle(for: snapshot)
-            overridesInheritedStyle = app.personalization.hasOverride(id: snapshot.scopedID)
+            overridesInheritedStyle = app.personalization.hasAppearanceOverride(id: snapshot.scopedID)
         case .image(let reference):
-            let own = app.personalization.imageDefault(for: reference)
-            overridesInheritedStyle = own != nil
-            style = own ?? inheritedStyle()
+            style = app.imageStyle(for: reference)
+            overridesInheritedStyle = app.personalization.hasImageAppearanceOverride(for: reference)
         case .imageTag(let reference, _):
-            let own = app.personalization.imageDefault(for: reference)
-            overridesInheritedStyle = own != nil
-            style = own ?? inheritedStyle()
+            style = app.imageStyle(for: reference)
+            overridesInheritedStyle = app.personalization.hasImageAppearanceOverride(for: reference)
         case .imageGroup(let group):
-            let own = app.personalization.imageGroupDefault(for: group)
-            overridesInheritedStyle = own != nil
-            style = own ?? inheritedStyle()
+            style = app.imageGroupStyle(for: group)
+            overridesInheritedStyle = app.personalization.hasImageGroupAppearanceOverride(for: group)
         case .volume(let name):
             style = app.volumeStyle(for: name)
             overridesInheritedStyle = true
@@ -394,33 +426,30 @@ struct CustomizeSheet: View {
     private func save() {
         switch target {
         case .image(let reference):
-            if overridesInheritedStyle {
-                app.personalization.setImageDefault(style, for: reference)
-            } else {
-                app.personalization.clearImageDefault(for: reference)
-            }
+            app.personalization.setImageDefault(savedImagePersonalization(), for: reference)
         case .imageTag(let reference, _):
-            if overridesInheritedStyle {
-                app.personalization.setImageDefault(style, for: reference)
-            } else {
-                app.personalization.clearImageDefault(for: reference)
-            }
+            app.personalization.setImageDefault(savedImagePersonalization(), for: reference)
         case .imageGroup(let group):
-            if overridesInheritedStyle {
-                app.personalization.setImageGroupDefault(style, for: group)
-            } else {
-                app.personalization.clearImageGroupDefault(for: group)
-            }
+            app.personalization.setImageGroupDefault(savedImagePersonalization(), for: group)
         case .container(let snapshot):
             if overridesInheritedStyle {
-                app.personalization.setOverride(style, for: snapshot.scopedID)
+                var containerStyle = style
+                containerStyle.appearanceOverrideEnabled = true
+                app.personalization.setOverride(containerStyle, for: snapshot.scopedID)
             } else {
-                app.personalization.clearOverride(id: snapshot.scopedID)
+                app.personalization.setOverride(style.containerMetadataOnly(), for: snapshot.scopedID)
             }
         case .volume(let name):
             app.personalization.setVolumeStyle(style, for: name)
         }
         dismiss()
+    }
+
+    private func savedImagePersonalization() -> Personalization {
+        guard overridesInheritedStyle else { return style.nicknameOnly() }
+        var saved = style
+        saved.appearanceOverrideEnabled = true
+        return saved
     }
 
     private func reset() {
@@ -439,8 +468,8 @@ struct CustomizeSheet: View {
 
     private func applyToImage() {
         guard case .container(let snapshot) = target else { return }
-        app.personalization.setImageDefault(style, for: snapshot.image)
-        app.personalization.clearOverride(id: snapshot.scopedID)
+        app.personalization.setImageDefault(style.appearanceOnly(), for: snapshot.image)
+        app.personalization.setOverride(style.containerMetadataOnly(), for: snapshot.scopedID)
         overridesInheritedStyle = false
         dismiss()
     }
@@ -461,11 +490,20 @@ struct CustomizeSheet: View {
     private func ownStyle() -> Personalization {
         switch target {
         case .container(let snapshot):
-            return app.personalization.hasOverride(id: snapshot.scopedID) ? app.containerStyle(for: snapshot) : inheritedStyle()
+            if let own = app.personalization.override(for: snapshot.scopedID), own.hasAppearanceCustomization {
+                return own
+            }
+            return inheritedStyle()
         case .image(let reference), .imageTag(let reference, _):
-            return app.personalization.imageDefault(for: reference) ?? inheritedStyle()
+            if let own = app.personalization.imageDefault(for: reference), own.hasAppearanceCustomization {
+                return own
+            }
+            return inheritedStyle()
         case .imageGroup(let group):
-            return app.personalization.imageGroupDefault(for: group) ?? inheritedStyle()
+            if let own = app.personalization.imageGroupDefault(for: group), own.hasAppearanceCustomization {
+                return own
+            }
+            return inheritedStyle()
         case .volume:
             return inheritedStyle()
         }

--- a/Sources/ContainedApp/Features/Containers/Customization/CustomizeWidgetsPanel.swift
+++ b/Sources/ContainedApp/Features/Containers/Customization/CustomizeWidgetsPanel.swift
@@ -7,7 +7,6 @@ import ContainedCore
 struct CustomizeWidgetsPanel: View {
     @Binding var style: Personalization
     let graphOptions: [Core.Metrics.GraphMetric]
-    let settingsDisabled: Bool
 
     private var activeWidgetIndices: [Int] {
         style.widgets.indices.filter { style.widget(at: $0).enabled }
@@ -37,8 +36,6 @@ struct CustomizeWidgetsPanel: View {
             Divider()
             widgetChartOptions(index)
         }
-        .disabled(settingsDisabled)
-        .opacity(settingsDisabled ? 0.48 : 1)
     }
 
     private var addWidgetSection: some View {
@@ -54,8 +51,6 @@ struct CustomizeWidgetsPanel: View {
                 .disabled(!canAddWidget)
             }
         }
-        .disabled(settingsDisabled)
-        .opacity(settingsDisabled ? 0.48 : 1)
     }
 
     private func widgetOrderControls(_ index: Int) -> some View {

--- a/Sources/ContainedApp/Features/Images/Style/CardStyleButton.swift
+++ b/Sources/ContainedApp/Features/Images/Style/CardStyleButton.swift
@@ -36,11 +36,11 @@ private extension CustomizeSheet.Target {
     func hasOwnStyle(in app: AppModel) -> Bool {
         switch self {
         case .container(let snapshot):
-            return app.personalization.hasOverride(id: snapshot.scopedID)
+            return app.personalization.hasAppearanceOverride(id: snapshot.scopedID)
         case .image(let reference), .imageTag(let reference, _):
-            return app.personalization.imageDefault(for: reference) != nil
+            return app.personalization.hasImageAppearanceOverride(for: reference)
         case .imageGroup(let group):
-            return app.personalization.imageGroupDefault(for: group) != nil
+            return app.personalization.hasImageGroupAppearanceOverride(for: group)
         case .volume:
             return true
         }

--- a/Sources/ContainedApp/Navigation/Toolbar/Panels/PaletteResultCard.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/Panels/PaletteResultCard.swift
@@ -86,7 +86,7 @@ struct PaletteResultCard: View {
                             elevated: false,
                             onTap: action,
                             title: name,
-                            subtitle: Format.shortImage(snapshot.image),
+                            subtitle: app.imageDisplayName(for: snapshot.image),
                             subtitleStyle: .monospaced) {
             UI.Card.IconChip(symbol: style.symbol,
                                  tint: style.color,
@@ -123,7 +123,7 @@ struct PaletteResultCard: View {
     }
 
     private func imageTagCard(_ reference: String, groupID: String) -> some View {
-        let style = app.imageGroupStyle(forID: groupID)
+        let style = app.imageStyle(for: reference)
         return UI.Card.Scaffold(size: .medium,
                             isSelected: selected,
                             fill: style.fillBackground ? style.color : nil,
@@ -133,7 +133,7 @@ struct PaletteResultCard: View {
                             blendMode: style.backgroundBlendMode,
                             elevated: false,
                             onTap: action,
-                            title: Format.shortImage(reference),
+                            title: app.imageDisplayName(for: reference),
                             subtitle: repositoryTitle(reference),
                             titleStyle: .monospaced) {
             UI.Card.IconChip(symbol: "tag",

--- a/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarImageGroupCard.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarImageGroupCard.swift
@@ -99,7 +99,7 @@ struct ToolbarImageGroupCard: View {
                             blendMode: resolved.backgroundBlendMode,
                             elevated: false,
                             onTap: onTap,
-                            title: repositoryTitle(group.primaryReference),
+                            title: resolved.displayName(fallback: repositoryTitle(group.primaryReference)),
                             subtitle: repositoryOwner(group.primaryReference),
                             pages: imagePages) {
             if let image {
@@ -483,7 +483,7 @@ struct ToolbarImageGroupCard: View {
                             gradientAngle: style.gradientAngle,
                             blendMode: style.backgroundBlendMode,
                             elevated: false,
-                            title: Format.shortImage(reference),
+                            title: app.imageDisplayName(for: reference),
                             subtitle: repositoryName(reference),
                             titleStyle: .monospaced) {
             CardStyleButton(style: style,

--- a/Sources/ContainedApp/Personalization/Personalization.swift
+++ b/Sources/ContainedApp/Personalization/Personalization.swift
@@ -8,13 +8,17 @@ import ContainedCore
 /// (image-level default).
 struct Personalization: Codable, Hashable, Sendable {
     /// Bump this whenever the stored shape changes so saved records normalize on load.
-    static let schemaVersion = 2
+    static let schemaVersion = 3
 
     var schemaVersion: Int = Self.schemaVersion
+    /// Persists an explicit per-container appearance override even when it matches built-in values.
+    var appearanceOverrideEnabled: Bool = false
     var tint: UI.Theme.Tint = .multicolor
     var iconEnabled: Bool = true
     var icon: String = ""            // SF Symbol name; empty = default
     var nickname: String = ""
+    /// Optional browser destination for this container. Empty means infer one from its published port.
+    var webURL: String = ""
     var fillBackground: Bool = true
     var backgroundOpacity: Double = Self.defaultBackgroundOpacity
     var gradient: Bool = true
@@ -66,11 +70,66 @@ struct Personalization: Codable, Hashable, Sendable {
     /// True when this is the untouched built-in style (nothing worth persisting).
     var isDefault: Bool { self == Personalization() }
 
+    /// Container appearance is the only part governed by image-style inheritance.
+    var hasAppearanceCustomization: Bool {
+        appearanceOverrideEnabled || appearanceDiffersFromDefaults
+    }
+
+    private var appearanceDiffersFromDefaults: Bool {
+        let defaults = Personalization()
+        return tint != defaults.tint
+            || iconEnabled != defaults.iconEnabled
+            || icon != defaults.icon
+            || fillBackground != defaults.fillBackground
+            || backgroundOpacity != defaults.backgroundOpacity
+            || gradient != defaults.gradient
+            || gradientAngle != defaults.gradientAngle
+            || backgroundBlendMode != defaults.backgroundBlendMode
+    }
+
+    mutating func applyAppearance(from source: Personalization) {
+        tint = source.tint
+        iconEnabled = source.iconEnabled
+        icon = source.icon
+        fillBackground = source.fillBackground
+        backgroundOpacity = source.backgroundOpacity
+        gradient = source.gradient
+        gradientAngle = source.gradientAngle
+        backgroundBlendMode = source.backgroundBlendMode
+    }
+
+    mutating func applyContainerMetadata(from source: Personalization) {
+        nickname = source.nickname
+        webURL = source.webURL
+        widgets = source.widgets
+        showStatusIndicator = source.showStatusIndicator
+        showStatusIcon = source.showStatusIcon
+        showStatusText = source.showStatusText
+    }
+
+    func containerMetadataOnly() -> Personalization {
+        var result = Personalization()
+        result.applyContainerMetadata(from: self)
+        return result
+    }
+
+    func appearanceOnly() -> Personalization {
+        var result = Personalization()
+        result.applyAppearance(from: self)
+        return result
+    }
+
+    func nicknameOnly() -> Personalization {
+        var result = Personalization()
+        result.nickname = nickname
+        return result
+    }
+
     init() {}
 
     enum CodingKeys: String, CodingKey {
-        case schemaVersion
-        case tint, iconEnabled, icon, nickname, fillBackground, backgroundOpacity, gradient, gradientAngle
+        case schemaVersion, appearanceOverrideEnabled
+        case tint, iconEnabled, icon, nickname, webURL, fillBackground, backgroundOpacity, gradient, gradientAngle
         case backgroundBlendMode
         case widgets, showStatusIndicator, showStatusIcon, showStatusText, graphMetric, graphStyle
     }
@@ -78,10 +137,12 @@ struct Personalization: Codable, Hashable, Sendable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         schemaVersion = try container.decodeIfPresent(Int.self, forKey: .schemaVersion) ?? 0
+        let savedAppearanceOverride = try container.decodeIfPresent(Bool.self, forKey: .appearanceOverrideEnabled)
         tint = try container.decodeIfPresent(UI.Theme.Tint.self, forKey: .tint) ?? .multicolor
         iconEnabled = try container.decodeIfPresent(Bool.self, forKey: .iconEnabled) ?? true
         icon = try container.decodeIfPresent(String.self, forKey: .icon) ?? ""
         nickname = try container.decodeIfPresent(String.self, forKey: .nickname) ?? ""
+        webURL = try container.decodeIfPresent(String.self, forKey: .webURL) ?? ""
         fillBackground = try container.decodeIfPresent(Bool.self, forKey: .fillBackground) ?? true
         backgroundOpacity = try container.decodeIfPresent(Double.self, forKey: .backgroundOpacity)
             ?? Self.defaultBackgroundOpacity
@@ -106,16 +167,19 @@ struct Personalization: Codable, Hashable, Sendable {
                 WidgetConfiguration(enabled: true, metric: .netTx, style: .area)
             ])
         }
+        appearanceOverrideEnabled = savedAppearanceOverride ?? appearanceDiffersFromDefaults
         schemaVersion = Self.schemaVersion
     }
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(Self.schemaVersion, forKey: .schemaVersion)
+        try container.encode(appearanceOverrideEnabled, forKey: .appearanceOverrideEnabled)
         try container.encode(tint, forKey: .tint)
         try container.encode(iconEnabled, forKey: .iconEnabled)
         try container.encode(icon, forKey: .icon)
         try container.encode(nickname, forKey: .nickname)
+        try container.encode(webURL, forKey: .webURL)
         try container.encode(fillBackground, forKey: .fillBackground)
         try container.encode(backgroundOpacity, forKey: .backgroundOpacity)
         try container.encode(gradient, forKey: .gradient)

--- a/Sources/ContainedApp/Personalization/PersonalizationStore.swift
+++ b/Sources/ContainedApp/Personalization/PersonalizationStore.swift
@@ -111,17 +111,48 @@ final class PersonalizationStore {
         return personalization.normalizedForPersistence()
     }
 
-    /// Resolve a container's effective style: per-container override -> image default -> fallback.
+    /// Resolve appearance through image inheritance while retaining container-only metadata.
     func resolved(id: String,
                   image: String,
                   group: Core.Image.LocalTagGroup? = nil,
                   fallback: Personalization = Personalization()) -> Personalization {
-        Self.meaningful(overrides[id]) ?? imageDefault(for: image, group: group) ?? fallback
+        let inheritedAppearance = resolvedImageAppearance(for: image,
+                                                          group: group,
+                                                          fallback: fallback)
+        guard let own = Self.meaningful(overrides[id]) else { return inheritedAppearance }
+        var resolved = own.hasAppearanceCustomization ? own : inheritedAppearance
+        resolved.applyContainerMetadata(from: own)
+        return resolved
     }
 
     // MARK: Per-container overrides
 
     func hasOverride(id: String) -> Bool { Self.meaningful(overrides[id]) != nil }
+
+    func hasAppearanceOverride(id: String) -> Bool {
+        Self.meaningful(overrides[id])?.hasAppearanceCustomization == true
+    }
+
+    func override(for id: String) -> Personalization? { Self.meaningful(overrides[id]) }
+
+    /// Resolve tag appearance independently from tag and image-group nicknames.
+    func resolvedImageAppearance(for image: String,
+                                 group: Core.Image.LocalTagGroup? = nil,
+                                 fallback: Personalization = Personalization()) -> Personalization {
+        let groupStyle = group.flatMap(imageGroupDefault(for:))
+        let inherited = groupStyle?.hasAppearanceCustomization == true ? groupStyle! : fallback
+        let tagStyle = imageDefault(for: image)
+        let resolved = tagStyle?.hasAppearanceCustomization == true ? tagStyle! : inherited
+        return resolved.appearanceOnly()
+    }
+
+    func hasImageAppearanceOverride(for image: String) -> Bool {
+        imageDefault(for: image)?.hasAppearanceCustomization == true
+    }
+
+    func hasImageGroupAppearanceOverride(for group: Core.Image.LocalTagGroup) -> Bool {
+        imageGroupDefault(for: group)?.hasAppearanceCustomization == true
+    }
 
     func setOverride(_ personalization: Personalization, for id: String) {
         if personalization.isDefault {

--- a/Tests/ContainedAppTests/PersonalizationStoreTests.swift
+++ b/Tests/ContainedAppTests/PersonalizationStoreTests.swift
@@ -44,6 +44,90 @@ struct PersonalizationStoreTests {
         })
     }
 
+    @Test func containerMetadataDoesNotBlockImageAppearanceInheritance() {
+        let database = AppDatabase(isStoredInMemoryOnly: true)
+        let store = PersonalizationStore(database: database)
+        var imageStyle = Personalization()
+        imageStyle.tint = .red
+        store.setImageDefault(imageStyle, for: "nginx:latest")
+
+        var metadata = Personalization()
+        metadata.nickname = "Dashboard"
+        metadata.webURL = "localhost:8080/admin"
+        metadata.showStatusText = false
+        store.setOverride(metadata, for: "docker:web")
+
+        let resolved = store.resolved(id: "docker:web", image: "nginx:latest")
+        #expect(resolved.tint == .red)
+        #expect(resolved.nickname == "Dashboard")
+        #expect(resolved.webURL == "localhost:8080/admin")
+        #expect(resolved.showStatusText == false)
+        #expect(store.hasOverride(id: "docker:web"))
+        #expect(!store.hasAppearanceOverride(id: "docker:web"))
+    }
+
+    @Test func browserDestinationFallsBackToPublishedPort() throws {
+        let snapshot = try Core.Container.JSON.decode(
+            Core.Container.Snapshot.self,
+            from: Data("""
+            {
+              "configuration": {
+                "id": "web",
+                "image": { "reference": "nginx:latest" },
+                "initProcess": {},
+                "publishedPorts": [{ "containerPort": 80, "hostPort": 8080 }]
+              },
+              "id": "web",
+              "status": { "state": "running" }
+            }
+            """.utf8),
+            runtimeKind: .docker
+        )
+
+        #expect(ContainerWebDestination.url(customValue: "", for: snapshot)?.absoluteString
+                == "http://localhost:8080")
+        #expect(ContainerWebDestination.url(customValue: "example.com/admin", for: snapshot)?.absoluteString
+                == "http://example.com/admin")
+    }
+
+    @Test func explicitDefaultAppearanceCanOverrideAnImageStyle() {
+        let database = AppDatabase(isStoredInMemoryOnly: true)
+        let store = PersonalizationStore(database: database)
+        var imageStyle = Personalization()
+        imageStyle.tint = .red
+        store.setImageDefault(imageStyle, for: "nginx:latest")
+
+        var containerStyle = Personalization()
+        containerStyle.appearanceOverrideEnabled = true
+        store.setOverride(containerStyle, for: "docker:web")
+
+        let resolved = store.resolved(id: "docker:web", image: "nginx:latest")
+        #expect(resolved.tint == .multicolor)
+        #expect(store.hasAppearanceOverride(id: "docker:web"))
+    }
+
+    @Test func imageAndTagNicknamesComposeWithoutBlockingAppearanceInheritance() throws {
+        let app = AppModel(database: AppDatabase(isStoredInMemoryOnly: true))
+        let reference = "testing.repo/biglongnameforimageurl/othertext:biglongnamefortag"
+        let group = try imageGroup(reference: reference, digest: "sha256:names")
+        app.setImages(group.images)
+
+        var imageStyle = Personalization()
+        imageStyle.tint = .red
+        imageStyle.nickname = "nice-image"
+        app.personalization.setImageGroupDefault(imageStyle, for: group)
+
+        var tagIdentity = Personalization()
+        tagIdentity.nickname = "latest"
+        app.personalization.setImageDefault(tagIdentity, for: reference)
+
+        #expect(app.imageGroupDisplayName(for: group) == "nice-image")
+        #expect(app.imageDisplayName(for: reference) == "nice-image:latest")
+        #expect(app.imageStyle(for: reference).tint == .red)
+        #expect(app.imageStyle(for: reference).nickname == "latest")
+        #expect(!app.personalization.hasImageAppearanceOverride(for: reference))
+    }
+
     private func imageGroup(reference: String,
                             digest: String) throws -> Core.Image.LocalTagGroup {
         let images = try Core.Container.JSON.decode(


### PR DESCRIPTION
## What changed

- infer browser shortcuts from published TCP ports and support per-container URL/path overrides
- combine appearance controls while keeping container-only metadata and widgets independent of image-style inheritance
- keep available updates visible as the persistent far-right container-card action
- scope image, tag, and container nicknames independently and compose friendly image references in card presentation

## Why

Container convenience metadata was previously coupled to visual inheritance, update actions disappeared with hover controls, and one nickname field represented several different resource identities. This makes those behaviors explicit without changing runtime image references or container configuration.

## Validation

- `swift build`
- `swift test --filter PersonalizationStoreTests`
- `xcodebuild -workspace Contained.xcworkspace -scheme Contained -configuration Debug build`
- `./Scripts/check.sh repo`
- `git diff --check`
