### PR TITLE
Refine image cards and grid presentation

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,1 @@
+- Refined image and container cards with clearer tag typography, stable update-check ordering, shared grid elevation, smoother expanded-card shadows, tighter responsive sizing, and more flexible window dimensions.

--- a/Packages/ContainedUI/Sources/ContainedUI/Card/Surface.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Card/Surface.swift
@@ -181,6 +181,8 @@ struct CardSurface<Header: View, BodyContent: View, FooterLeading: View,
             }
             .animation(.spring(response: 0.42, dampingFraction: 0.86), value: isExpanded)
             .animation(reduceMotion ? nil : .spring(response: 0.42, dampingFraction: 0.86),
+                       value: elevated)
+            .animation(reduceMotion ? nil : .spring(response: 0.42, dampingFraction: 0.86),
                        value: usesExpandedRadius)
             .animation(.spring(response: 0.42, dampingFraction: 0.86), value: cornerRadiusOverride)
             .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: compactContentIsMuted)
@@ -342,12 +344,11 @@ private struct CardMaterialSurface: ViewModifier {
         content
             .clipShape(shape)
             .background {
-                if shadow {
-                    ExteriorShadow(cornerRadius: cornerRadius,
-                                   color: shadowColor,
-                                   radius: shadowRadius,
-                                   y: shadowY)
-                }
+                ExteriorShadow(cornerRadius: cornerRadius,
+                               color: shadowColor,
+                               radius: shadowRadius,
+                               y: shadowY)
+                    .opacity(shadow ? 1 : 0)
             }
             .background {
                 ZStack {

--- a/Packages/ContainedUI/Sources/ContainedUI/List/ListRows.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/List/ListRows.swift
@@ -3,14 +3,29 @@ import SwiftUI
 public extension UI.List {
 struct Stack<Content: View>: View {
     public var spacing: CGFloat
-    public var padding: CGFloat
+    public var padding: EdgeInsets
     @ViewBuilder public var content: () -> Content
 
     public init(spacing: CGFloat = UI.Tokens.Space.s,
                 padding: CGFloat = UI.Tokens.Space.s,
                 @ViewBuilder content: @escaping () -> Content) {
         self.spacing = spacing
-        self.padding = padding
+        self.padding = EdgeInsets(top: padding,
+                                  leading: padding,
+                                  bottom: padding,
+                                  trailing: padding)
+        self.content = content
+    }
+
+    public init(spacing: CGFloat = UI.Tokens.Space.s,
+                horizontalPadding: CGFloat,
+                verticalPadding: CGFloat,
+                @ViewBuilder content: @escaping () -> Content) {
+        self.spacing = spacing
+        self.padding = EdgeInsets(top: verticalPadding,
+                                  leading: horizontalPadding,
+                                  bottom: verticalPadding,
+                                  trailing: horizontalPadding)
         self.content = content
     }
 

--- a/Packages/ContainedUI/Sources/ContainedUI/Surface/ExteriorShadow.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Surface/ExteriorShadow.swift
@@ -29,6 +29,22 @@ struct ExteriorShadow: View {
     }
 }
 
+public extension UI.Card.Grid {
+    /// Elevates a collection of cards as one rendered layer so card shadows cannot draw over
+    /// neighboring cards. Individual cards in the collection should disable their own elevation.
+    struct Elevation: ViewModifier {
+        public init() {}
+
+        public func body(content: Content) -> some View {
+            content
+                .compositingGroup()
+                .shadow(color: UI.Theme.Material.elevatedSurfaceShadow,
+                        radius: UI.Theme.Material.elevatedSurfaceShadowRadius,
+                        y: UI.Theme.Material.elevatedSurfaceShadowY)
+        }
+    }
+}
+
 #Preview("Exterior Shadow") {
     ZStack {
         ExteriorShadow(cornerRadius: UI.Tokens.Radius.card,

--- a/Packages/ContainedUI/Sources/ContainedUI/Tokens/UI.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Tokens/UI.swift
@@ -64,7 +64,7 @@ enum Tokens {
         public static let compactMax: CGFloat = 400
         public static let largeMin: CGFloat = 240
         public static let largeMax: CGFloat = 520
-        public static let largePreferred: CGFloat = 320
+        public static let largePreferred: CGFloat = 300
     }
 
     /// Canonical sheet dimensions — expose through `UI.Panel.SheetSize` for app and UX use. Replaces ad-hoc

--- a/Sources/ContainedApp/App/AppModel+ResourceStyles.swift
+++ b/Sources/ContainedApp/App/AppModel+ResourceStyles.swift
@@ -58,6 +58,14 @@ extension AppModel {
         return "\(repository)\(separator)\(tagNickname ?? parsed.reference)"
     }
 
+    /// A tag card represents the tag itself, not the repository. Keep its user nickname scoped to
+    /// the tag and fall back to the parsed tag/digest value; the full reference belongs underneath.
+    func imageTagDisplayName(for reference: String) -> String {
+        let savedNickname = personalization.imageDefault(for: reference)?.nickname
+        let nickname = savedNickname.flatMap(Self.nonEmptyNickname)
+        return nickname ?? Core.Registry.ImageReference.parse(reference).reference
+    }
+
     func imageGroupDisplayName(for group: Core.Image.LocalTagGroup) -> String? {
         let savedNickname = personalization.imageGroupDefault(for: group)?.nickname
         return savedNickname.flatMap(Self.nonEmptyNickname)

--- a/Sources/ContainedApp/App/ContainedApp.swift
+++ b/Sources/ContainedApp/App/ContainedApp.swift
@@ -17,7 +17,7 @@ public struct ContainedApplication: App {
                 .environment(app)
                 .environment(ui)
                 .modelContainer(app.historyStore.container)
-                .frame(minWidth: 720, minHeight: 480)
+                .frame(minWidth: 720, minHeight: 300)
                 .toolbar {
                     ToolbarItem(placement: .automatic) {
                         Color.clear
@@ -27,7 +27,7 @@ public struct ContainedApplication: App {
                 }
         }
         .windowStyle(.hiddenTitleBar)
-        .defaultSize(width: 1200, height: 800)
+        .defaultSize(width: 1280, height: 800)
         .commands {
             CommandGroup(replacing: .appInfo) {
                 Button("About Contained") {

--- a/Sources/ContainedApp/Features/Containers/Card/ContainerCard.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainerCard.swift
@@ -145,6 +145,7 @@ struct ContainerCard: View {
                      gradient: styleForDisplay.gradient,
                      gradientAngle: styleForDisplay.gradientAngle,
                      blendMode: styleForDisplay.backgroundBlendMode,
+                     elevated: isExpanded && controlsVisible,
                      onTap: onTap,
                      persistentFooterActions: persistentFooterActions,
                      title: name,

--- a/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
@@ -80,6 +80,7 @@ struct ContainersGridView: View {
                                     gridCard(snapshot)
                                 }
                             }
+                            .modifier(UI.Card.Grid.Elevation())
                             Color.clear
                                 .frame(height: UI.Toolbar.Size.band + UI.Card.Grid.toolbarClearanceAdjustment)
                         }

--- a/Sources/ContainedApp/Navigation/Toolbar/AppToolbar.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/AppToolbar.swift
@@ -235,7 +235,7 @@ struct AppToolbar: View {
                                           originFrame: usableToolbarImageSource ?? .zero,
                                           target: .anchored(size: toolbarImageDetailSize,
                                                             safeArea: toolbarMorphSafeArea(for: .updates),
-                                                            margin: 16),
+                                                            margin: 0),
                                           backdropStyle: .dim,
                                           showsBackdrop: true,
                                           closeRequestToken: toolbarImageCloseRequestToken,

--- a/Sources/ContainedApp/Navigation/Toolbar/Panels/PaletteResultCard.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/Panels/PaletteResultCard.swift
@@ -136,9 +136,11 @@ struct PaletteResultCard: View {
                             blendMode: style.backgroundBlendMode,
                             elevated: false,
                             onTap: action,
-                            title: app.imageDisplayName(for: reference),
-                            subtitle: repositoryTitle(reference),
-                            titleStyle: .monospaced) {
+                            persistentFooterActions: AnyView(accessory),
+                            title: app.imageTagDisplayName(for: reference),
+                            subtitle: reference,
+                            titleStyle: .monospaced,
+                            subtitleStyle: .monospaced) {
             UI.Card.IconChip(symbol: "tag",
                                  tint: style.color,
                                  backgroundOpacity: selected
@@ -162,7 +164,7 @@ struct PaletteResultCard: View {
                     .designSecondaryValueStyle()
             }
         } footerActions: {
-            accessory
+            EmptyView()
         } widget: {
             EmptyView()
         }
@@ -279,11 +281,6 @@ struct PaletteResultCard: View {
             Text(reason)
                 .designTertiaryCaption()
         }
-    }
-
-    private func repositoryTitle(_ reference: String) -> String {
-        let parsed = Core.Registry.ImageReference.parse(reference)
-        return parsed.repository.split(separator: "/").map(String.init).last ?? parsed.repository
     }
 
     private func imageUpdateText(_ status: Core.Image.UpdateStatus) -> String {

--- a/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarImageGroupCard.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarImageGroupCard.swift
@@ -107,6 +107,8 @@ struct ToolbarImageGroupCard: View {
                             onTap: onTap,
                             title: resolved.displayName(fallback: repositoryTitle(group.primaryReference)),
                             subtitle: repositoryOwner(group.primaryReference),
+                            titleStyle: .monospaced,
+                            subtitleStyle: .monospaced,
                             pages: isExpanded ? imagePages : nil) {
             if let image {
                 CardStyleButton(style: resolved,
@@ -160,7 +162,7 @@ struct ToolbarImageGroupCard: View {
         let image = group.images.first { $0.reference == reference } ?? primaryImage(group)
         let variant = image?.variants.first(where: \.isRunnable) ?? image?.variants.first
         let history = variant?.config?.history ?? []
-        return imagePageBody(title: AppText.string("image.history", defaultValue: "History"), subtitle: Format.shortImage(reference)) {
+        return imagePageBody(title: AppText.string("image.history", defaultValue: "History"), subtitle: reference) {
             if history.isEmpty {
                 UI.State.Empty(AppText.string("image.history.empty", defaultValue: "No history"),
                                  systemImage: "clock",
@@ -190,7 +192,7 @@ struct ToolbarImageGroupCard: View {
     }
 
     private func tagPage(_ source: String) -> some View {
-        imagePageBody(title: AppText.addTag, subtitle: Format.shortImage(source)) {
+        imagePageBody(title: AppText.addTag, subtitle: source) {
             UI.Card.InsetSection {
                 UI.Panel.Field(label: AppText.string("image.tag.source", defaultValue: "Source")) {
                     Text(Format.shortImage(source)).designSecondaryValueStyle()
@@ -215,7 +217,7 @@ struct ToolbarImageGroupCard: View {
     }
 
     private func pushPage(_ reference: String) -> some View {
-        imagePageBody(title: AppText.string("image.pushImage", defaultValue: "Push image"), subtitle: Format.shortImage(reference)) {
+        imagePageBody(title: AppText.string("image.pushImage", defaultValue: "Push image"), subtitle: reference) {
             if pushStartedReference == reference,
                let client = app.client,
                let runtimeKind = pushRuntimeKind(for: reference) {
@@ -460,17 +462,12 @@ struct ToolbarImageGroupCard: View {
     }
 
     private func tagList(_ group: Core.Image.LocalTagGroup) -> some View {
-        VStack(alignment: .leading, spacing: UI.Layout.Spacing.s) {
-            Text("Tags")
-                .designHeadlineLabelStyle()
-                .padding(.leading, UI.Layout.Spacing.xs)
-            VStack(spacing: UI.Layout.Spacing.s) {
-                ForEach(group.tags) { tag in
-                    tagRow(tag, in: group)
-                        .frame(maxWidth: .infinity)
-                }
+        UI.List.Stack(horizontalPadding: UI.Layout.Spacing.s,
+                      verticalPadding: 0) {
+            ForEach(group.tags) { tag in
+                tagRow(tag, in: group)
+                    .frame(maxWidth: .infinity)
             }
-            .padding(UI.Layout.Spacing.s)
         }
     }
 
@@ -484,9 +481,11 @@ struct ToolbarImageGroupCard: View {
                             gradientAngle: style.gradientAngle,
                             blendMode: style.backgroundBlendMode,
                             elevated: false,
-                            title: app.imageDisplayName(for: reference),
-                            subtitle: repositoryName(reference),
-                            titleStyle: .monospaced) {
+                            persistentFooterActions: AnyView(tagFooterActions(tag)),
+                            title: app.imageTagDisplayName(for: reference),
+                            subtitle: reference,
+                            titleStyle: .monospaced,
+                            subtitleStyle: .monospaced) {
             CardStyleButton(style: style,
                             target: .imageTag(reference: reference, groupID: group.id),
                             help: "Customize image style",
@@ -506,16 +505,22 @@ struct ToolbarImageGroupCard: View {
                 UI.Card.MetricText(text: app.runtimeDescriptor(for: tag.runtimeKind)?.displayName ?? tag.runtimeKind.rawValue)
             }
         } footerActions: {
-            footerAction("play", help: AppText.run) {
-                ui.runImage(reference, runtimeKind: tag.runtimeKind)
-                if isExpanded { onClose() }
-            }
-            UI.Copy.Icon(value: reference, help: AppText.copyReference)
-            footerAction("trash", help: AppText.deleteTag, role: .destructive) { deletingTag = tag }
+            EmptyView()
         } widget: {
             EmptyView()
         }
         .contextMenu { tagMenu(tag, in: group) }
+    }
+
+    @ViewBuilder
+    private func tagFooterActions(_ tag: Core.Image.LocalTag) -> some View {
+        let reference = tag.reference
+        footerAction("play", help: AppText.run) {
+            ui.runImage(reference, runtimeKind: tag.runtimeKind)
+            if isExpanded { onClose() }
+        }
+        UI.Copy.Icon(value: reference, help: AppText.copyReference)
+        footerAction("trash", help: AppText.deleteTag, role: .destructive) { deletingTag = tag }
     }
 
     /// Right-click actions for a single tag — mirrors the footer buttons so the row is consistent with
@@ -601,14 +606,6 @@ struct ToolbarImageGroupCard: View {
         case .checking: return .info
         case .unknown: return .neutral
         }
-    }
-
-    private func repositoryName(_ reference: String) -> String {
-        let parsed = Core.Registry.ImageReference.parse(reference)
-        if parsed.registry == "registry-1.docker.io", parsed.repository.hasPrefix("library/") {
-            return String(parsed.repository.dropFirst("library/".count))
-        }
-        return parsed.repository
     }
 
     private func repositoryTitle(_ reference: String) -> String {

--- a/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarUpdatesPanel.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarUpdatesPanel.swift
@@ -12,6 +12,13 @@ struct ToolbarUpdatesPanel: View {
     var onOpenImage: (Core.Image.LocalTagGroup, CGRect) -> Void
     var onClose: () -> Void
     @State private var imageFrames: [Core.Image.LocalTagGroup.ID: CGRect] = [:]
+    @State private var settledUpdateStates: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState] = [:]
+
+    private var liveUpdateStates: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState] {
+        app.localImageGroups().reduce(into: [:]) { states, group in
+            states[group.id] = app.imageUpdateStatus(for: group.primaryReference).state
+        }
+    }
 
     private var imageGroups: [Core.Image.LocalTagGroup] {
         sortedImageGroups(app.localImageGroups().filter(matchesFilter))
@@ -34,7 +41,7 @@ struct ToolbarUpdatesPanel: View {
 
     private var updateCount: Int {
         app.localImageGroups().filter {
-            app.imageUpdateStatus(for: $0.primaryReference).state == .updateAvailable
+            effectiveUpdateState(for: $0) == .updateAvailable
         }.count
     }
 
@@ -61,6 +68,12 @@ struct ToolbarUpdatesPanel: View {
                 }
             }
             .padding(UI.Layout.Spacing.s)
+        }
+        .onAppear {
+            rememberSettledUpdateStates(liveUpdateStates)
+        }
+        .onChange(of: liveUpdateStates) { _, states in
+            rememberSettledUpdateStates(states)
         }
         .task { await app.refreshImagesIfNeeded() }
     }
@@ -173,12 +186,11 @@ struct ToolbarUpdatesPanel: View {
     }
 
     private func imageRank(_ group: Core.Image.LocalTagGroup) -> Int {
-        switch app.imageUpdateStatus(for: group.primaryReference).state {
+        switch effectiveUpdateState(for: group) {
         case .updateAvailable: return 0
         case .error: return 1
-        case .checking: return 2
-        case .unknown: return 3
-        case .current: return 4
+        case .checking, .unknown: return 2
+        case .current: return 3
         }
     }
 
@@ -203,9 +215,9 @@ struct ToolbarUpdatesPanel: View {
         case .all:
             return true
         case .updates:
-            return app.imageUpdateStatus(for: group.primaryReference).state == .updateAvailable
+            return effectiveUpdateState(for: group) == .updateAvailable
         case .errors:
-            return app.imageUpdateStatus(for: group.primaryReference).state == .error
+            return effectiveUpdateState(for: group) == .error
         }
     }
 
@@ -215,11 +227,10 @@ struct ToolbarUpdatesPanel: View {
     }
 
     private func statusTitle(_ group: Core.Image.LocalTagGroup) -> String {
-        switch app.imageUpdateStatus(for: group.primaryReference).state {
+        switch effectiveUpdateState(for: group) {
         case .updateAvailable: return "Updates available"
         case .error: return "Errors"
-        case .checking: return "Checking"
-        case .unknown: return "Unknown"
+        case .checking, .unknown: return "Unknown"
         case .current: return "Current"
         }
     }
@@ -228,10 +239,26 @@ struct ToolbarUpdatesPanel: View {
         switch title {
         case "Updates available": return 0
         case "Errors": return 1
-        case "Checking": return 2
-        case "Unknown": return 3
-        default: return 4
+        case "Unknown": return 2
+        default: return 3
         }
+    }
+
+    private func effectiveUpdateState(for group: Core.Image.LocalTagGroup) -> Core.Image.UpdateState {
+        let liveState = app.imageUpdateStatus(for: group.primaryReference).state
+        guard liveState == .checking else { return liveState }
+        return settledUpdateStates[group.id] ?? .unknown
+    }
+
+    private func rememberSettledUpdateStates(
+        _ states: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState]
+    ) {
+        var settled = settledUpdateStates.filter { states[$0.key] != nil }
+        for (id, state) in states where state != .checking {
+            settled[id] = state
+        }
+        guard settled != settledUpdateStates else { return }
+        settledUpdateStates = settled
     }
 
 }

--- a/Tests/ContainedAppTests/ContainerGridProjectionTests.swift
+++ b/Tests/ContainedAppTests/ContainerGridProjectionTests.swift
@@ -6,7 +6,7 @@ import ContainedUI
 @Suite("Container grid projection")
 struct ContainerGridProjectionTests {
     @Test func stableColumnsDependOnlyOnViewportWidth() {
-        #expect(UI.Card.Grid.stableColumns(availableWidth: 1_600, spacing: 16).count == 4)
+        #expect(UI.Card.Grid.stableColumns(availableWidth: 1_600, spacing: 16).count == 5)
         #expect(UI.Card.Grid.stableColumns(availableWidth: 1_200, spacing: 16).count == 3)
         #expect(UI.Card.Grid.stableColumns(availableWidth: 1_000, spacing: 16).count == 3)
         #expect(UI.Card.Grid.stableColumns(availableWidth: 600, spacing: 16).count == 1)


### PR DESCRIPTION
## What changed

- Refine image and tag card typography, titles, subtitles, persistent actions, and expanded content spacing.
- Keep image ordering, grouping, filtering, and update counts stable while update checks are running.
- Move compact container shadows to one shared composited grid layer, while animating the expanded card's own elevation.
- Tighten responsive card sizing, lower the app's minimum height, widen its default launch size, and remove the expanded image target margin.
- Extend `UI.List.Stack` with independent horizontal and vertical padding.

## Why

Image cards had redundant tag chrome and inconsistent reference presentation, while transient `checking` state reordered the updates list. Per-card shadows could also paint over neighboring cards. These changes make the card system calmer, more consistent, and more responsive without adding app-local styling shims.

## Validation

- `./Scripts/check.sh repo`
- `swift build`
- `git diff --check`
- Repeated packaged debug builds via `./Scripts/build.sh run --verify`
