### PR TITLE
Fix sparkline clipping and expand container sorting

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,1 @@
+- Prevented sparkline strokes and marks from clipping at chart boundaries, and expanded container sorting by activity, age, runtime, and attention state.

--- a/Packages/ContainedUI/Sources/ContainedUI/Chart/Sparkline.swift
+++ b/Packages/ContainedUI/Sources/ContainedUI/Chart/Sparkline.swift
@@ -144,10 +144,16 @@ struct Sparkline: View {
         let secondary = SparklineGeometry.series(comparisonSamples, scale: comparisonScale,
                                                  capacity: Self.maximumPlottedSamples)
         return Canvas(opaque: false, colorMode: .nonLinear, rendersAsynchronously: true) { context, size in
+            let renderingInset = SparklineGeometry.renderingInset(for: style,
+                                                                  lineWidth: lineWidth,
+                                                                  pointArea: pointSize,
+                                                                  barWidth: barWidth)
             let primaryPoints = SparklineGeometry.points(primary, in: size,
-                                                         capacity: Self.maximumPlottedSamples)
+                                                         capacity: Self.maximumPlottedSamples,
+                                                         renderingInset: renderingInset)
             let secondaryPoints = SparklineGeometry.points(secondary, in: size,
-                                                           capacity: Self.maximumPlottedSamples)
+                                                           capacity: Self.maximumPlottedSamples,
+                                                           renderingInset: renderingInset)
             let stroke = StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round)
             switch style {
             case .area:
@@ -262,6 +268,24 @@ struct SparklineSeriesPoint: Equatable, Sendable {
 }
 
 enum SparklineGeometry {
+    static func renderingInset(for style: UI.Chart.GraphStyle,
+                               lineWidth: CGFloat,
+                               pointArea: CGFloat,
+                               barWidth: CGFloat) -> CGSize {
+        switch style {
+        case .area, .line, .multiLine:
+            let radius = max(lineWidth, 0) / 2
+            return CGSize(width: radius, height: radius)
+        case .bar, .range:
+            // Bars extend horizontally around their sample and retain a half-point minimum
+            // height so an all-zero series remains visible without crossing the canvas edge.
+            return CGSize(width: max(barWidth, 0) / 2, height: 0.5)
+        case .points, .scatter:
+            let radius = pointRadius(forArea: pointArea)
+            return CGSize(width: radius, height: radius)
+        }
+    }
+
     static func series(_ values: [Double], scale: UI.Chart.Scale,
                        capacity: Int) -> [SparklineSeriesPoint] {
         let latest = values.suffix(capacity).map(SparklineSeriesScaling.sanitizedSample)
@@ -271,12 +295,20 @@ enum SparklineGeometry {
     }
 
     static func points(_ series: [SparklineSeriesPoint], in size: CGSize,
-                       capacity: Int) -> [CGPoint] {
+                       capacity: Int, renderingInset: CGSize = .zero) -> [CGPoint] {
+        let insetWidth = min(max(renderingInset.width, 0), max(size.width, 0) / 2)
+        let insetHeight = min(max(renderingInset.height, 0), max(size.height, 0) / 2)
+        let plotWidth = max(size.width - insetWidth * 2, 0)
+        let plotHeight = max(size.height - insetHeight * 2, 0)
         let divisor = CGFloat(max(capacity - 1, 1))
         return series.map { point in
-            CGPoint(x: CGFloat(point.index) / divisor * size.width,
-                    y: (1 - CGFloat(min(max(point.value, 0), 1))) * size.height)
+            CGPoint(x: insetWidth + CGFloat(point.index) / divisor * plotWidth,
+                    y: insetHeight + (1 - CGFloat(min(max(point.value, 0), 1))) * plotHeight)
         }
+    }
+
+    static func pointRadius(forArea area: CGFloat) -> CGFloat {
+        max(sqrt(max(area, 1)), 1) / 2
     }
 
     static func path(_ points: [CGPoint], interpolation: UI.Chart.Interpolation) -> Path {
@@ -345,7 +377,7 @@ enum SparklineGeometry {
 
     static func drawPoints(_ points: [CGPoint], area: CGFloat, color: Color,
                            in context: inout GraphicsContext) {
-        let diameter = max(sqrt(max(area, 1)), 1)
+        let diameter = pointRadius(forArea: area) * 2
         for point in points {
             let rect = CGRect(x: point.x - diameter / 2, y: point.y - diameter / 2,
                               width: diameter, height: diameter)

--- a/Packages/ContainedUI/Tests/ContainedUITests/SparklineScalingTests.swift
+++ b/Packages/ContainedUI/Tests/ContainedUITests/SparklineScalingTests.swift
@@ -63,4 +63,56 @@ struct SparklineScalingTests {
         #expect(primary.map(\.index) == [21, 22, 23])
         #expect(secondary.map(\.index) == [22, 23])
     }
+
+    @Test func lineGeometryKeepsCenteredStrokeInsideEveryPlotBoundary() {
+        let size = CGSize(width: 240, height: 60)
+        let inset = SparklineGeometry.renderingInset(for: .line, lineWidth: 4,
+                                                     pointArea: 18, barWidth: 4)
+        let series = [
+            SparklineSeriesPoint(index: 0, value: 0),
+            SparklineSeriesPoint(index: 23, value: 1),
+        ]
+        let points = SparklineGeometry.points(series, in: size, capacity: 24,
+                                              renderingInset: inset)
+
+        #expect(points == [CGPoint(x: 2, y: 58), CGPoint(x: 238, y: 2)])
+    }
+
+    @Test func pointGeometryUsesRenderedDiameterAsItsBoundaryInset() {
+        let size = CGSize(width: 100, height: 40)
+        let inset = SparklineGeometry.renderingInset(for: .scatter, lineWidth: 1.5,
+                                                     pointArea: 36, barWidth: 4)
+        let series = [
+            SparklineSeriesPoint(index: 0, value: 1),
+            SparklineSeriesPoint(index: 23, value: 0),
+        ]
+        let points = SparklineGeometry.points(series, in: size, capacity: 24,
+                                              renderingInset: inset)
+
+        #expect(inset == CGSize(width: 3, height: 3))
+        #expect(points == [CGPoint(x: 3, y: 3), CGPoint(x: 97, y: 37)])
+    }
+
+    @Test func barGeometryAccountsForWidthAndMinimumVisibleHeight() {
+        let size = CGSize(width: 100, height: 40)
+        let inset = SparklineGeometry.renderingInset(for: .bar, lineWidth: 1.5,
+                                                     pointArea: 18, barWidth: 8)
+        let series = [
+            SparklineSeriesPoint(index: 0, value: 1),
+            SparklineSeriesPoint(index: 23, value: 0),
+        ]
+        let points = SparklineGeometry.points(series, in: size, capacity: 24,
+                                              renderingInset: inset)
+
+        #expect(inset == CGSize(width: 4, height: 0.5))
+        #expect(points == [CGPoint(x: 4, y: 0.5), CGPoint(x: 96, y: 39.5)])
+    }
+
+    @Test func oversizedMarksCollapseSafelyToTheCanvasCenter() {
+        let series = [SparklineSeriesPoint(index: 23, value: 1)]
+        let points = SparklineGeometry.points(series, in: CGSize(width: 4, height: 2), capacity: 24,
+                                              renderingInset: CGSize(width: 20, height: 20))
+
+        #expect(points == [CGPoint(x: 2, y: 1)])
+    }
 }

--- a/Sources/ContainedApp/Features/Containers/Card/ContainerGridProjection.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainerGridProjection.swift
@@ -3,11 +3,38 @@ import ContainedCore
 import Observation
 
 struct ContainerGridProjection: Equatable, Sendable {
+    struct SortValues: Equatable, Sendable {
+        var displayName: String
+        var creationDate: Date?
+        var startedDate: Date?
+        var health: Core.Container.HealthStatus
+        var imageUpdate: Core.Image.ContainerUpdateState
+        var cpuCoreFraction: Double?
+        var memoryFraction: Double?
+
+        init(displayName: String,
+             creationDate: Date? = nil,
+             startedDate: Date? = nil,
+             health: Core.Container.HealthStatus = .unknown,
+             imageUpdate: Core.Image.ContainerUpdateState = .unknown,
+             cpuCoreFraction: Double? = nil,
+             memoryFraction: Double? = nil) {
+            self.displayName = displayName
+            self.creationDate = creationDate
+            self.startedDate = startedDate
+            self.health = health
+            self.imageUpdate = imageUpdate
+            self.cpuCoreFraction = cpuCoreFraction
+            self.memoryFraction = memoryFraction
+        }
+    }
+
     struct Input: Equatable, Sendable {
         let snapshots: [Core.Container.Snapshot]
         let sort: ContainerSort
         let runningOnly: Bool
         let search: String
+        var sortValuesByID: [String: SortValues] = [:]
     }
 
     let containers: [Core.Container.Snapshot]
@@ -18,34 +45,98 @@ struct ContainerGridProjection: Equatable, Sendable {
     static func build(_ input: Input) -> ContainerGridProjection {
         let query = input.search.trimmingCharacters(in: .whitespacesAndNewlines)
         let filtered = input.snapshots.filter { snapshot in
-            (!input.runningOnly || snapshot.state == .running) &&
-                (query.isEmpty || snapshot.displayName.localizedCaseInsensitiveContains(query) ||
+            let displayName = input.sortValuesByID[snapshot.scopedID]?.displayName ?? snapshot.displayName
+            return (!input.runningOnly || snapshot.state == .running) &&
+                (query.isEmpty || displayName.localizedCaseInsensitiveContains(query) ||
+                    snapshot.displayName.localizedCaseInsensitiveContains(query) ||
                     snapshot.image.localizedCaseInsensitiveContains(query))
         }
-        return ContainerGridProjection(containers: sorted(filtered, by: input.sort))
+        return ContainerGridProjection(containers: sorted(filtered, by: input.sort,
+                                                          valuesByID: input.sortValuesByID))
     }
 
     private static func sorted(_ containers: [Core.Container.Snapshot],
-                               by sort: ContainerSort) -> [Core.Container.Snapshot] {
-        switch sort {
-        case .name:
-            return containers.sorted {
-                $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+                               by sort: ContainerSort,
+                               valuesByID: [String: SortValues]) -> [Core.Container.Snapshot] {
+        containers.sorted { lhs, rhs in
+            let lhsValues = valuesByID[lhs.scopedID] ?? SortValues(displayName: lhs.displayName)
+            let rhsValues = valuesByID[rhs.scopedID] ?? SortValues(displayName: rhs.displayName)
+            let ordered: Bool?
+            switch sort {
+            case .name:
+                ordered = compareText(lhsValues.displayName, rhsValues.displayName)
+            case .status:
+                ordered = compareAscending(statusRank(lhs, health: lhsValues.health),
+                                           statusRank(rhs, health: rhsValues.health))
+            case .created:
+                ordered = compareDescending(lhsValues.creationDate, rhsValues.creationDate)
+            case .uptime:
+                ordered = compareAscending(lhsValues.startedDate, rhsValues.startedDate)
+            case .image:
+                ordered = compareText(lhs.image, rhs.image)
+            case .runtime:
+                ordered = compareText(lhs.runtimeKind.rawValue, rhs.runtimeKind.rawValue)
+            case .cpu:
+                ordered = compareDescending(lhsValues.cpuCoreFraction, rhsValues.cpuCoreFraction)
+            case .memory:
+                ordered = compareDescending(lhsValues.memoryFraction, rhsValues.memoryFraction)
+            case .attention:
+                ordered = compareAscending(attentionRank(lhs, values: lhsValues),
+                                           attentionRank(rhs, values: rhsValues))
             }
-        case .status:
-            return containers.sorted { lhs, rhs in
-                let lhsRunning = lhs.state == .running
-                let rhsRunning = rhs.state == .running
-                if lhsRunning != rhsRunning { return lhsRunning }
-                return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
-            }
-        case .image:
-            return containers.sorted { lhs, rhs in
-                let comparison = lhs.image.localizedCaseInsensitiveCompare(rhs.image)
-                if comparison != .orderedSame { return comparison == .orderedAscending }
-                return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
-            }
+            if let ordered { return ordered }
+            if let byName = compareText(lhsValues.displayName, rhsValues.displayName) { return byName }
+            return lhs.scopedID < rhs.scopedID
         }
+    }
+
+    private static func compareText(_ lhs: String, _ rhs: String) -> Bool? {
+        let comparison = lhs.localizedCaseInsensitiveCompare(rhs)
+        return comparison == .orderedSame ? nil : comparison == .orderedAscending
+    }
+
+    private static func compareAscending<T: Comparable>(_ lhs: T, _ rhs: T) -> Bool? {
+        lhs == rhs ? nil : lhs < rhs
+    }
+
+    private static func compareAscending<T: Comparable>(_ lhs: T?, _ rhs: T?) -> Bool? {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?): return compareAscending(lhs, rhs)
+        case (_?, nil): return true
+        case (nil, _?): return false
+        case (nil, nil): return nil
+        }
+    }
+
+    private static func compareDescending<T: Comparable>(_ lhs: T?, _ rhs: T?) -> Bool? {
+        switch (lhs, rhs) {
+        case let (lhs?, rhs?): return lhs == rhs ? nil : lhs > rhs
+        case (_?, nil): return true
+        case (nil, _?): return false
+        case (nil, nil): return nil
+        }
+    }
+
+    private static func statusRank(_ snapshot: Core.Container.Snapshot,
+                                   health: Core.Container.HealthStatus) -> Int {
+        if health == .unhealthy { return 0 }
+        switch snapshot.state {
+        case .stopping: return 1
+        case .unknown: return 2
+        case .stopped: return 3
+        case .running: return 4
+        }
+    }
+
+    private static func attentionRank(_ snapshot: Core.Container.Snapshot,
+                                      values: SortValues) -> Int {
+        if values.health == .unhealthy { return 0 }
+        if snapshot.state == .unknown { return 1 }
+        if snapshot.state == .stopping { return 2 }
+        if values.imageUpdate == .updateAvailable { return 3 }
+        if values.imageUpdate == .updateReady { return 4 }
+        if snapshot.state == .stopped { return 5 }
+        return 6
     }
 }
 

--- a/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
+++ b/Sources/ContainedApp/Features/Containers/Card/ContainersGridView.swift
@@ -36,24 +36,36 @@ struct ContainersGridView: View {
     @State private var detailSourceFrame: CGRect?
     @State private var projectionState = ContainerGridProjectionState()
     @State private var selectedWidgetIndices: [String: Int] = [:]
+    @State private var liveSortRefresh = 0
 
     private let detailSpring = Animation.spring(response: 0.42, dampingFraction: 0.86)
 
     private var store: ContainersStore { app.containers }
 
     private var projectionInput: ContainerGridProjection.Input {
-        ContainerGridProjection.Input(snapshots: ui.containers(in: store.snapshots),
+        let snapshots = ui.containers(in: store.snapshots)
+        let includeMetrics = ui.sort.usesLiveMetrics
+        let includeHealth = ui.sort == .status || ui.sort == .attention
+        let includeUpdates = ui.sort == .attention
+        if includeMetrics { _ = liveSortRefresh }
+        let sortValues = Dictionary(uniqueKeysWithValues: snapshots.map { snapshot in
+            let stats = includeMetrics ? store.statsByID[snapshot.scopedID] : nil
+            let style = app.containerStyle(for: snapshot)
+            return (snapshot.scopedID, ContainerGridProjection.SortValues(
+                displayName: style.displayName(fallback: snapshot.id),
+                creationDate: snapshot.configuration.creationDate,
+                startedDate: snapshot.startedDate,
+                health: includeHealth ? app.health.status(for: snapshot.scopedID) : .unknown,
+                imageUpdate: includeUpdates ? app.containerImageUpdateState(for: snapshot) : .unknown,
+                cpuCoreFraction: stats?.cpuCoreFraction,
+                memoryFraction: stats?.memoryFraction
+            ))
+        })
+        return ContainerGridProjection.Input(snapshots: snapshots,
                                       sort: ui.sort,
                                       runningOnly: ui.runningOnly,
-                                      search: ui.search.text)
-    }
-
-    private var projectionKey: ContainerGridProjectionKey {
-        ContainerGridProjectionKey(inventoryRevision: store.inventoryRevision,
-                                   sort: ui.sort,
-                                   runningOnly: ui.runningOnly,
-                                   search: ui.search.text,
-                                   containerGroupRevision: ui.containerGroupRevision)
+                                      search: ui.search.text,
+                                      sortValuesByID: sortValues)
     }
 
     var body: some View {
@@ -147,7 +159,15 @@ struct ContainersGridView: View {
             Text(request.isUpdate ? AppText.updateContainerConfirmation : AppText.rebuildContainerConfirmation)
         }
         .refreshable { await store.refresh() }
-        .task(id: projectionKey) { await projectionState.update(projectionInput) }
+        .task(id: projectionInput) { await projectionState.update(projectionInput) }
+        .task(id: ui.sort) {
+            guard ui.sort.usesLiveMetrics else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(5))
+                guard !Task.isCancelled else { return }
+                liveSortRefresh &+= 1
+            }
+        }
         .sensoryFeedback(.success, trigger: lifecycleFeedback)
         // Report the in-page search count so the toolbar can escalate an empty search into the palette.
         .onAppear { ui.search.pageResultCount = projectionState.projection.visibleCount }
@@ -407,14 +427,6 @@ struct ContainersGridView: View {
             ? AppText.string("containers.empty.runningOnly", defaultValue: "No running containers.")
             : AppText.string("containers.empty.description", defaultValue: "Run a container to see it here.")
     }
-}
-
-private struct ContainerGridProjectionKey: Hashable {
-    let inventoryRevision: Int
-    let sort: ContainerSort
-    let runningOnly: Bool
-    let search: String
-    let containerGroupRevision: Int
 }
 
 private struct ContainerCardMetricsRenderer: View {

--- a/Sources/ContainedApp/Features/Containers/Customization/ContainerViewOptions.swift
+++ b/Sources/ContainedApp/Features/Containers/Customization/ContainerViewOptions.swift
@@ -2,23 +2,37 @@ import Foundation
 
 /// How containers are ordered in the main grid.
 enum ContainerSort: String, CaseIterable, Identifiable, Codable, Sendable {
-    case name, status, image
+    case name, status, created, uptime, image, runtime, cpu, memory, attention
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .name:   return AppText.string("filter.name", defaultValue: "Name")
-        case .status: return AppText.string("filter.status", defaultValue: "Status")
-        case .image:  return AppText.string("filter.image", defaultValue: "Image")
+        case .name:      return AppText.string("filter.name", defaultValue: "Name")
+        case .status:    return AppText.string("filter.status", defaultValue: "Status")
+        case .created:   return AppText.string("filter.created", defaultValue: "Newest")
+        case .uptime:    return AppText.string("filter.uptime", defaultValue: "Longest Running")
+        case .image:     return AppText.string("filter.image", defaultValue: "Image")
+        case .runtime:   return AppText.string("filter.runtime", defaultValue: "Runtime")
+        case .cpu:       return AppText.string("filter.cpuUsage", defaultValue: "CPU Usage")
+        case .memory:    return AppText.string("filter.memoryUsage", defaultValue: "Memory Usage")
+        case .attention: return AppText.string("filter.needsAttention", defaultValue: "Needs Attention")
         }
     }
 
     var symbol: String {
         switch self {
-        case .name:   return "textformat"
-        case .status: return "bolt"
-        case .image:  return "shippingbox"
+        case .name:      return "textformat"
+        case .status:    return "bolt"
+        case .created:   return "calendar"
+        case .uptime:    return "clock.arrow.circlepath"
+        case .image:     return "shippingbox"
+        case .runtime:   return "server.rack"
+        case .cpu:       return "cpu"
+        case .memory:    return "memorychip"
+        case .attention: return "exclamationmark.triangle"
         }
     }
+
+    var usesLiveMetrics: Bool { self == .cpu || self == .memory }
 }

--- a/Sources/ContainedApp/Resources/Localizable.xcstrings
+++ b/Sources/ContainedApp/Resources/Localizable.xcstrings
@@ -2279,6 +2279,12 @@
     "filter.allNetworks" : {
 
     },
+    "filter.cpuUsage" : {
+
+    },
+    "filter.created" : {
+
+    },
     "filter.builtInOnly" : {
 
     },
@@ -2297,10 +2303,16 @@
     "filter.kind" : {
 
     },
+    "filter.memoryUsage" : {
+
+    },
     "filter.mode" : {
 
     },
     "filter.name" : {
+
+    },
+    "filter.needsAttention" : {
 
     },
     "filter.network" : {
@@ -2321,7 +2333,13 @@
     "filter.runningOnly" : {
 
     },
+    "filter.runtime" : {
+
+    },
     "filter.status" : {
+
+    },
+    "filter.uptime" : {
 
     },
     "filter.updatesOnly" : {

--- a/Tests/ContainedAppTests/ContainerGridProjectionTests.swift
+++ b/Tests/ContainedAppTests/ContainerGridProjectionTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 import ContainedCore
 import ContainedUI
 @testable import ContainedApp
@@ -68,9 +69,60 @@ struct ContainerGridProjectionTests {
         #expect(state.projection.containers.map(\.id) == ["newest"])
     }
 
+    @Test func richSortOptionsUseStableInventoryAndDerivedValues() {
+        let apple = Self.snapshot(id: "apple", image: "example/z:latest", state: .running)
+        let docker = Self.snapshot(id: "docker", image: "example/a:latest", state: .stopped,
+                                   runtimeKind: .docker)
+        let worker = Self.snapshot(id: "worker", image: "example/m:latest", state: .stopping)
+        let snapshots = [apple, docker, worker]
+        let values: [String: ContainerGridProjection.SortValues] = [
+            apple.scopedID: .init(displayName: "Zebra", creationDate: Date(timeIntervalSince1970: 10),
+                                  startedDate: Date(timeIntervalSince1970: 20),
+                                  cpuCoreFraction: 0.25, memoryFraction: 0.9),
+            docker.scopedID: .init(displayName: "Alpha", creationDate: Date(timeIntervalSince1970: 30),
+                                   imageUpdate: .updateAvailable,
+                                   cpuCoreFraction: 0.8, memoryFraction: 0.2),
+            worker.scopedID: .init(displayName: "Middle", creationDate: Date(timeIntervalSince1970: 20),
+                                   startedDate: Date(timeIntervalSince1970: 40), health: .unhealthy,
+                                   cpuCoreFraction: 0.5, memoryFraction: 0.5),
+        ]
+
+        func ids(sortedBy sort: ContainerSort) -> [String] {
+            ContainerGridProjection.build(.init(snapshots: snapshots, sort: sort,
+                                                runningOnly: false, search: "",
+                                                sortValuesByID: values)).containers.map(\.id)
+        }
+
+        #expect(ids(sortedBy: .name) == ["docker", "worker", "apple"])
+        #expect(ids(sortedBy: .status) == ["worker", "docker", "apple"])
+        #expect(ids(sortedBy: .created) == ["docker", "worker", "apple"])
+        #expect(ids(sortedBy: .uptime) == ["apple", "worker", "docker"])
+        #expect(ids(sortedBy: .image) == ["docker", "worker", "apple"])
+        #expect(ids(sortedBy: .runtime) == ["worker", "apple", "docker"])
+        #expect(ids(sortedBy: .cpu) == ["docker", "worker", "apple"])
+        #expect(ids(sortedBy: .memory) == ["apple", "worker", "docker"])
+        #expect(ids(sortedBy: .attention) == ["worker", "docker", "apple"])
+    }
+
+    @Test func nicknameParticipatesInSearchWithoutHidingTheRuntimeID() {
+        let snapshot = Self.snapshot(id: "api", image: "example/api:latest")
+        let values = [snapshot.scopedID: ContainerGridProjection.SortValues(displayName: "Gateway")]
+
+        let nicknameMatch = ContainerGridProjection.build(.init(snapshots: [snapshot], sort: .name,
+                                                                 runningOnly: false, search: "gate",
+                                                                 sortValuesByID: values))
+        let idMatch = ContainerGridProjection.build(.init(snapshots: [snapshot], sort: .name,
+                                                           runningOnly: false, search: "api",
+                                                           sortValuesByID: values))
+
+        #expect(nicknameMatch.containers.map(\.id) == ["api"])
+        #expect(idMatch.containers.map(\.id) == ["api"])
+    }
+
     private static func snapshot(id: String,
                                  image: String,
+                                 state: Core.Runtime.Status = .running,
                                  runtimeKind: Core.Runtime.Kind = .appleContainer) -> Core.Container.Snapshot {
-        .placeholder(id: id, image: image, runtimeKind: runtimeKind)
+        .placeholder(id: id, image: image, state: state, runtimeKind: runtimeKind)
     }
 }


### PR DESCRIPTION
## Summary

- inset shared `ContainedUI` sparkline geometry by each graph style's largest stroke or mark so rendering remains inside every Canvas boundary
- add container sorting by displayed name, attention-ranked status, newest creation, longest uptime, image, runtime, CPU, memory, and combined attention state
- refresh live metric sorts on a bounded five-second cadence and make nickname search match both the displayed name and runtime ID
- add focused geometry and container projection regression coverage

## Root cause

Sparkline points were mapped into the full Canvas bounds, placing extrema and endpoints directly on the edges even though centered strokes and marks extended beyond them.

The container grid projection also only received inventory snapshots, limiting sorting to raw name, basic running status, and image.

## Validation

- `swift test` — 130 tests passed
- `swift test --package-path Packages/ContainedUI` — 21 tests passed
- `./Scripts/check.sh repo`
- `git diff --check`
- `./Scripts/package.sh app debug`
