### PR TITLE
Group image tags by repository

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,3 @@
+# Changes Since Last Nightly
+
+- Group all local tags and versions from the same image repository into one image card while preserving each tag's digest and runtime availability.

--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,3 +1,5 @@
 # Changes Since Last Nightly
 
 - Group all local tags and versions from the same image repository into one image card while preserving each tag's digest and runtime availability.
+- Split the Images panel into Updates and Images pages, with update-aware defaults and page-specific image management controls.
+- Reduced panel opening work by projecting and refreshing only the active page.

--- a/Packages/ContainedCore/Sources/ContainedCore/Image/LocalTagGroup.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Image/LocalTagGroup.swift
@@ -63,9 +63,16 @@ struct LocalTagGroup: Identifiable, Sendable, Hashable {
                 }
                 return lhs.reference.localizedCaseInsensitiveCompare(rhs.reference) == .orderedAscending
             }
-            let digest = sortedImages.compactMap(\.digest).first
+            let repositoryKeys = Set(sortedImages.map {
+                Core.Registry.ImageReference.normalizedRepositoryKey($0.reference)
+            })
+            let digests = Set(sortedImages.compactMap(\.digest).filter { !$0.isEmpty })
+            let digest = digests.count == 1 ? digests.first : nil
+            let id = repositoryKeys.count == 1
+                ? repositoryKeys.first!
+                : digest ?? repositoryKeys.sorted().first!
             return Core.Image.LocalTagGroup(
-                id: digest ?? Core.Registry.ImageReference.normalizedKey(references[0]),
+                id: id,
                 digest: digest,
                 references: references,
                 tags: tags,
@@ -77,7 +84,7 @@ struct LocalTagGroup: Identifiable, Sendable, Hashable {
 
     public static func group(containing image: Core.Image.Resource, in images: [Core.Image.Resource]) -> Core.Image.LocalTagGroup {
         groups(for: images).first { $0.images.contains(image) }
-            ?? Core.Image.LocalTagGroup(id: image.digest ?? Core.Registry.ImageReference.normalizedKey(image.reference),
+            ?? Core.Image.LocalTagGroup(id: Core.Registry.ImageReference.normalizedRepositoryKey(image.reference),
                                         digest: image.digest,
                                         references: [image.reference],
                                         tags: [Core.Image.LocalTag(reference: image.reference,
@@ -87,7 +94,7 @@ struct LocalTagGroup: Identifiable, Sendable, Hashable {
     }
 
     private static func groupKeys(for image: Core.Image.Resource) -> [String] {
-        var keys = ["ref:\(Core.Registry.ImageReference.normalizedKey(image.reference))"]
+        var keys = ["repository:\(Core.Registry.ImageReference.normalizedRepositoryKey(image.reference))"]
         if let digest = image.digest, !digest.isEmpty { keys.append("digest:\(digest)") }
         return keys
     }

--- a/Packages/ContainedCore/Sources/ContainedCore/Registry/ImageReference.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Registry/ImageReference.swift
@@ -14,10 +14,14 @@ struct ImageReference: Sendable, Hashable {
 
     public var authScope: String { "repository:\(repository):pull" }
 
-    public var normalizedKey: String {
+    public var normalizedRepositoryKey: String {
         let displayRegistry = registry == "registry-1.docker.io" ? "docker.io" : registry
+        return "\(displayRegistry)/\(repository)"
+    }
+
+    public var normalizedKey: String {
         let separator = isDigestReference ? "@" : ":"
-        return "\(displayRegistry)/\(repository)\(separator)\(reference)"
+        return "\(normalizedRepositoryKey)\(separator)\(reference)"
     }
 
     public static func parse(_ raw: String) -> Core.Registry.ImageReference {
@@ -73,6 +77,10 @@ struct ImageReference: Sendable, Hashable {
 
     public static func normalizedKey(_ raw: String) -> String {
         parse(raw).normalizedKey
+    }
+
+    public static func normalizedRepositoryKey(_ raw: String) -> String {
+        parse(raw).normalizedRepositoryKey
     }
 }
 

--- a/Packages/ContainedCore/Tests/ContainedCoreTests/ImageWorkflowTests.swift
+++ b/Packages/ContainedCore/Tests/ContainedCoreTests/ImageWorkflowTests.swift
@@ -9,6 +9,7 @@ struct ImageWorkflowTests {
         #expect(official.registry == "registry-1.docker.io")
         #expect(official.repository == "library/nginx")
         #expect(official.reference == "latest")
+        #expect(official.normalizedRepositoryKey == "docker.io/library/nginx")
         #expect(official.normalizedKey == "docker.io/library/nginx:latest")
 
         let namespaced = Core.Registry.ImageReference.parse("docker.io/tdeverx/app:nightly")
@@ -108,6 +109,29 @@ struct ImageWorkflowTests {
         let tagIDs = group?.tags.map(\.id) ?? []
         #expect(runtimeKinds == Set([Core.Runtime.Kind.appleContainer, .docker]))
         #expect(tagIDs.allSatisfy { $0.contains("::") })
+    }
+
+    @Test func localTagGroupingCombinesRepositoryVersionsWithDistinctDigests() {
+        let develop = Self.image(reference: "ghcr.io/seerr-team/seerr:develop",
+                                 digest: "sha256:develop",
+                                 runtimeKind: .appleContainer)
+        let latest = Self.image(reference: "ghcr.io/seerr-team/seerr:latest",
+                                digest: "sha256:latest",
+                                runtimeKind: .appleContainer)
+        let unrelated = Self.image(reference: "ghcr.io/other-team/seerr:latest",
+                                   digest: "sha256:other",
+                                   runtimeKind: .appleContainer)
+
+        let groups = Core.Image.LocalTagGroup.groups(for: [develop, latest, unrelated])
+
+        #expect(groups.count == 2)
+        let seerr = groups.first { $0.id == "ghcr.io/seerr-team/seerr" }
+        #expect(seerr?.references == [
+            "ghcr.io/seerr-team/seerr:develop",
+            "ghcr.io/seerr-team/seerr:latest",
+        ])
+        #expect(seerr?.tags.count == 2)
+        #expect(seerr?.digest == nil)
     }
 
     @Test func hubSearchFetchesThroughSharedHelper() async throws {

--- a/Sources/ContainedApp/App/AppModel+ImageUpdates.swift
+++ b/Sources/ContainedApp/App/AppModel+ImageUpdates.swift
@@ -50,6 +50,19 @@ extension AppModel {
             ?? Core.Image.UpdateStatus()
     }
 
+    /// Aggregate every runtime-owned tag in a repository group without rescanning the image inventory.
+    func imageUpdateStatus(for group: Core.Image.LocalTagGroup) -> Core.Image.UpdateStatus {
+        aggregateUpdateStatus(group.tags.map {
+            imageUpdateStatus(for: $0.reference, runtimeKind: $0.runtimeKind)
+        })
+    }
+
+    func firstImageTagWithUpdate(in group: Core.Image.LocalTagGroup) -> Core.Image.LocalTag? {
+        group.tags.first {
+            imageUpdateStatus(for: $0.reference, runtimeKind: $0.runtimeKind).state == .updateAvailable
+        }
+    }
+
     /// Combine registry state with the immutable image identity captured when a container was
     /// created. A successful pull makes the registry status current, but leaves the old container
     /// pointing at its previous identity until it is recreated.
@@ -142,6 +155,24 @@ extension AppModel {
                           runtimeKind: Core.Runtime.Kind,
                           notify: Bool = true) async {
         await checkImageUpdate(reference, runtimeKinds: [runtimeKind], notify: notify)
+    }
+
+    func checkImageUpdates(in group: Core.Image.LocalTagGroup) async {
+        for tag in group.tags {
+            await checkImageUpdate(tag.reference, runtimeKind: tag.runtimeKind, notify: false)
+        }
+        let status = imageUpdateStatus(for: group)
+        let name = Format.shortImage(group.primaryReference)
+        switch status.state {
+        case .updateAvailable:
+            flash(AppText.imageUpdateAvailable(name))
+        case .current:
+            flash(AppText.imageUpToDate(name))
+        case .error:
+            flash(status.message ?? AppText.string("updates.checkFailed", defaultValue: "Update check failed"))
+        case .checking, .unknown:
+            break
+        }
     }
 
     private func checkImageUpdate(_ reference: String,

--- a/Sources/ContainedApp/App/AppModel.swift
+++ b/Sources/ContainedApp/App/AppModel.swift
@@ -725,13 +725,18 @@ final class AppModel {
         historyStore.recordMetrics(deltas, at: observedAt)
     }
 
-    /// Refresh the data behind the System toolbar panel (volumes, networks, and a forced `system df`). Called from
-    /// the panel's `.task` since System is no longer a standing page refreshed by the tick.
+    /// Refresh all mutable System-panel resources after cleanup operations that affect several pages.
     func refreshSystemResources() async {
         guard client != nil, bootstrap == .ready else { return }
         await refreshDiskUsage(force: true)
         await refreshVolumes()
         await refreshNetworks()
+    }
+
+    /// Refresh only the data displayed on the System panel's Runtime page.
+    func refreshSystemRuntimeResources() async {
+        guard client != nil, bootstrap == .ready else { return }
+        await refreshDiskUsage(force: true)
     }
 
     /// Refresh the registry-login list for Settings.

--- a/Sources/ContainedApp/Features/Palette/CommandPalette.swift
+++ b/Sources/ContainedApp/Features/Palette/CommandPalette.swift
@@ -319,23 +319,21 @@ struct PaletteItem: Identifiable {
                                      visual: .imageGroup(group),
                                      icon: "arrow.triangle.2.circlepath",
                                      tint: .blue) {
-                Task { await app.checkImageUpdate(group.primaryReference) }
+                Task { await app.checkImageUpdates(in: group) }
             })
-            if app.imageUpdateStatus(for: group.primaryReference).state == .updateAvailable {
-                if let runtimeKind = group.images.first(where: { $0.reference == group.primaryReference })?.runtimeKind {
-                    items.append(PaletteItem(title: AppText.palettePullImageUpdate(Format.shortImage(group.primaryReference)),
-                                             subtitle: AppText.paletteImageSubtitle,
-                                             keywords: group.references,
-                                             kind: .image,
-                                             visual: .imageGroup(group),
-                                             icon: "arrow.down.circle",
-                                             tint: .orange) {
-                        Task {
-                            await app.pullImageUpdate(group.primaryReference,
-                                                      runtimeKind: runtimeKind)
-                        }
-                    })
-                }
+            if let tag = app.firstImageTagWithUpdate(in: group) {
+                items.append(PaletteItem(title: AppText.palettePullImageUpdate(Format.shortImage(tag.reference)),
+                                         subtitle: AppText.paletteImageSubtitle,
+                                         keywords: group.references,
+                                         kind: .image,
+                                         visual: .imageGroup(group),
+                                         icon: "arrow.down.circle",
+                                         tint: .orange) {
+                    Task {
+                        await app.pullImageUpdate(tag.reference,
+                                                  runtimeKind: tag.runtimeKind)
+                    }
+                })
             }
             let primaryRuntime = group.images.first { $0.reference == group.primaryReference }?.runtimeKind
                 ?? group.tags.first?.runtimeKind

--- a/Sources/ContainedApp/Features/System/SystemView.swift
+++ b/Sources/ContainedApp/Features/System/SystemView.swift
@@ -62,6 +62,19 @@ struct SystemContent: View {
         page = item
     }
 
+    private func refreshActivePage() async {
+        switch activePage {
+        case .runtime:
+            await app.refreshSystemRuntimeResources()
+        case .automation:
+            break
+        case .volumes:
+            await app.refreshVolumes()
+        case .networks:
+            await app.refreshNetworks()
+        }
+    }
+
     init(elevated: Bool = true,
          onClose: @escaping () -> Void = {}) {
         self.elevated = elevated
@@ -105,7 +118,7 @@ struct SystemContent: View {
             }
             .padding(UI.Layout.Spacing.s)
         }
-        .task { await app.refreshSystemResources() }
+        .task(id: activePage) { await refreshActivePage() }
         .confirmationDialog("Delete volume \(deletingVolume?.name ?? "")?",
                             isPresented: deletingVolumeBinding, presenting: deletingVolume) { volume in
             Button("Delete", role: .destructive) { Task { await deleteVolume(volume) } }

--- a/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarImageGroupCard.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarImageGroupCard.swift
@@ -90,7 +90,7 @@ struct ToolbarImageGroupCard: View {
 
     private var rootCard: some View {
         let image = primaryImage(group)
-        let status = app.imageUpdateStatus(for: group.primaryReference)
+        let status = app.imageUpdateStatus(for: group)
         let resolved = app.imageGroupStyle(for: group)
         return UI.Card.Scaffold(size: .medium,
                             isExpanded: isExpanded,
@@ -444,14 +444,13 @@ struct ToolbarImageGroupCard: View {
             }
         }
         footerAction("arrow.triangle.2.circlepath", help: AppText.checkForUpdates) {
-            Task { await app.checkImageUpdate(group.primaryReference) }
+            Task { await app.checkImageUpdates(in: group) }
         }
-        if app.imageUpdateStatus(for: group.primaryReference).state == .updateAvailable,
-           let runtimeKind = primaryImage(group)?.runtimeKind {
+        if let tag = app.firstImageTagWithUpdate(in: group) {
             footerAction("arrow.down.circle", help: AppText.pullUpdate, tint: .orange) {
                 Task {
-                    await app.pullImageUpdate(group.primaryReference,
-                                              runtimeKind: runtimeKind)
+                    await app.pullImageUpdate(tag.reference,
+                                              runtimeKind: tag.runtimeKind)
                 }
             }
         }
@@ -565,15 +564,14 @@ struct ToolbarImageGroupCard: View {
             Button { save(image) } label: { Label("Save to tar…", systemImage: "arrow.up.doc") }
         }
         Divider()
-        Button { Task { await app.checkImageUpdate(group.primaryReference) } } label: {
+        Button { Task { await app.checkImageUpdates(in: group) } } label: {
             Label("Check for Updates", systemImage: "arrow.triangle.2.circlepath")
         }
-        if app.imageUpdateStatus(for: group.primaryReference).state == .updateAvailable,
-           let runtimeKind = primaryImage(group)?.runtimeKind {
+        if let tag = app.firstImageTagWithUpdate(in: group) {
             Button {
                 Task {
-                    await app.pullImageUpdate(group.primaryReference,
-                                              runtimeKind: runtimeKind)
+                    await app.pullImageUpdate(tag.reference,
+                                              runtimeKind: tag.runtimeKind)
                 }
             } label: {
                 Label("Pull Update", systemImage: "arrow.down.circle")

--- a/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarUpdatesPanel.swift
+++ b/Sources/ContainedApp/Navigation/Toolbar/Panels/ToolbarUpdatesPanel.swift
@@ -13,50 +13,58 @@ struct ToolbarUpdatesPanel: View {
     var onClose: () -> Void
     @State private var imageFrames: [Core.Image.LocalTagGroup.ID: CGRect] = [:]
     @State private var settledUpdateStates: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState] = [:]
+    @State private var page: ImagePage?
 
-    private var liveUpdateStates: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState] {
-        app.localImageGroups().reduce(into: [:]) { states, group in
-            states[group.id] = app.imageUpdateStatus(for: group.primaryReference).state
+    enum ImagePage: String, CaseIterable, Identifiable {
+        case updates = "Updates"
+        case images = "Images"
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .updates: return AppText.string("image.page.updates", defaultValue: "Updates")
+            case .images: return AppText.sectionImages
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .updates: return "arrow.down.circle"
+            case .images: return "square.stack.3d.up"
+            }
+        }
+
+        static func defaultPage(updateCount: Int) -> Self {
+            updateCount > 0 ? .updates : .images
         }
     }
 
-    private var imageGroups: [Core.Image.LocalTagGroup] {
-        sortedImageGroups(app.localImageGroups().filter(matchesFilter))
-    }
+    private struct Projection {
+        var activePage: ImagePage
+        var liveUpdateStates: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState]
+        var updateCount: Int
+        var groups: [Core.Image.LocalTagGroup]
+        var sections: [(title: String, groups: [Core.Image.LocalTagGroup])]
 
-    private var imageSections: [(title: String, groups: [Core.Image.LocalTagGroup])] {
-        switch ui.imageGrouping {
-        case .none:
-            return [("", imageGroups)]
-        case .registry:
-            return Dictionary(grouping: imageGroups, by: registryTitle)
-                .map { ($0.key, sortedImageGroups($0.value)) }
-                .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
-        case .status:
-            return Dictionary(grouping: imageGroups, by: statusTitle)
-                .map { ($0.key, sortedImageGroups($0.value)) }
-                .sorted { lhs, rhs in statusRank(lhs.title) < statusRank(rhs.title) }
+        var isCheckingForUpdates: Bool {
+            liveUpdateStates.values.contains(.checking)
         }
-    }
-
-    private var updateCount: Int {
-        app.localImageGroups().filter {
-            effectiveUpdateState(for: $0) == .updateAvailable
-        }.count
     }
 
     var body: some View {
+        let projection = makeProjection()
         UI.Panel.Scaffold(width: UI.Panel.Size.images.width) {
             VStack(alignment: .leading, spacing: 0) {
-                header
+                header(projection)
                 Divider()
             }
         } content: {
             LazyVStack(alignment: .leading, spacing: UI.Layout.Spacing.s) {
-                if imageGroups.isEmpty {
-                    emptyCard
+                if projection.groups.isEmpty {
+                    emptyCard(for: projection.activePage)
                 } else {
-                    ForEach(Array(imageSections.enumerated()), id: \.offset) { _, section in
+                    ForEach(Array(projection.sections.enumerated()), id: \.offset) { _, section in
                         if ui.imageGrouping != .none {
                             UI.Badge.Text(text: section.title, font: .caption.weight(.semibold))
                                 .padding(.horizontal, UI.Layout.Spacing.xs)
@@ -70,22 +78,39 @@ struct ToolbarUpdatesPanel: View {
             .padding(UI.Layout.Spacing.s)
         }
         .onAppear {
-            rememberSettledUpdateStates(liveUpdateStates)
+            rememberSettledUpdateStates(projection.liveUpdateStates)
         }
-        .onChange(of: liveUpdateStates) { _, states in
+        .onChange(of: projection.liveUpdateStates) { _, states in
             rememberSettledUpdateStates(states)
         }
         .task { await app.refreshImagesIfNeeded() }
     }
 
-    private var header: some View {
-        UI.Panel.Header(symbol: "square.stack.3d.up",
+    private func header(_ projection: Projection) -> some View {
+        UI.Panel.Header(symbol: projection.activePage.systemImage,
                     title: AppText.sectionImages,
-                    subtitle: AppText.string("image.updates.subtitle", defaultValue: "\(imageGroups.count) local · \(updateCount) update\(updateCount == 1 ? "" : "s")")) {
-            UI.Action.Cluster {
-                imageFilterMenu
-                UI.Action.Items(imageHeaderActions)
+                    subtitle: headerSubtitle(for: projection)) {
+            HStack(spacing: UI.Toolbar.Spacing.groupSpacing) {
+                UI.Action.Group(checkForUpdatesAction(isChecking: projection.isCheckingForUpdates))
+                if projection.activePage == .images {
+                    UI.Action.Cluster {
+                        imageFilterMenu
+                        UI.Action.Items(imagePageActions)
+                    }
+                }
+                UI.Action.Group(navigationActions(activePage: projection.activePage))
             }
+        }
+    }
+
+    private func headerSubtitle(for projection: Projection) -> String {
+        switch projection.activePage {
+        case .updates:
+            return AppText.string("image.page.updates.subtitle",
+                                  defaultValue: "\(projection.updateCount) update\(projection.updateCount == 1 ? "" : "s") available")
+        case .images:
+            return AppText.string("image.updates.subtitle",
+                                  defaultValue: "\(projection.groups.count) local · \(projection.updateCount) update\(projection.updateCount == 1 ? "" : "s")")
         }
     }
 
@@ -118,30 +143,49 @@ struct ToolbarUpdatesPanel: View {
         .buttonStyle(.plain)
     }
 
-    private var imageHeaderActions: [UI.Action.Item] {
-        var actions = [
+    private func checkForUpdatesAction(isChecking: Bool) -> UI.Action.Item {
+        UI.Action.Item(systemName: "arrow.triangle.2.circlepath",
+                       help: AppText.runImageUpdateCheckNow,
+                       isEnabled: !isChecking) {
+            Task { await app.runImageUpdateSweepNow() }
+        }
+    }
+
+    private var imagePageActions: [UI.Action.Item] {
+        [
             UI.Action.Item(systemName: "square.and.arrow.down", help: AppText.loadImageTar) {
                     ui.dispatch(.loadImage)
                     onClose()
-            },
-            UI.Action.Item(systemName: "arrow.triangle.2.circlepath", help: AppText.checkForUpdates) {
-                    Task { await app.runImageUpdateSweepNow() }
             },
             UI.Action.Item(systemName: "trash", help: AppText.pruneImages, role: .destructive) {
                     ui.dispatch(.pruneImages)
                     onClose()
             }
         ]
-        actions.append(UI.Action.Item(systemName: "xmark", help: AppText.close, isCancel: true, action: onClose))
+    }
+
+    private func navigationActions(activePage: ImagePage) -> [UI.Action.Item] {
+        var actions = ImagePage.allCases.map { item in
+            UI.Action.Item(systemName: item.systemImage,
+                           help: item.title,
+                           tint: activePage == item ? .accentColor : nil) {
+                page = item
+            }
+        }
+        actions.append(UI.Action.Item(systemName: "xmark",
+                                     help: AppText.close,
+                                     isCancel: true,
+                                     action: onClose))
         return actions
     }
 
-    private var emptyCard: some View {
+    private func emptyCard(for page: ImagePage) -> some View {
         UI.Card.Scaffold(size: .small,
                      elevated: false,
-                     title: AppText.string("image.empty", defaultValue: "No images"),
-                     subtitle: AppText.string("image.empty.subtitle", defaultValue: "Pull or build an image to see it here")) {
-            UI.Card.IconChip(symbol: "checkmark.circle.fill", tint: .green)
+                     title: emptyTitle(for: page),
+                     subtitle: emptySubtitle(for: page)) {
+            UI.Card.IconChip(symbol: page == .updates ? "checkmark.circle.fill" : "square.stack.3d.up",
+                             tint: page == .updates ? .green : .secondary)
         } titleAccessory: {
             EmptyView()
         } subtitleAccessory: {
@@ -156,6 +200,22 @@ struct ToolbarUpdatesPanel: View {
             EmptyView()
         } widget: {
             EmptyView()
+        }
+    }
+
+    private func emptyTitle(for page: ImagePage) -> String {
+        switch page {
+        case .updates: return AppText.string("image.updates.empty", defaultValue: "No image updates")
+        case .images: return AppText.string("image.empty", defaultValue: "No images")
+        }
+    }
+
+    private func emptySubtitle(for page: ImagePage) -> String {
+        switch page {
+        case .updates:
+            return AppText.string("image.updates.empty.subtitle", defaultValue: "Your local images are up to date")
+        case .images:
+            return AppText.string("image.empty.subtitle", defaultValue: "Pull or build an image to see it here")
         }
     }
 
@@ -185,8 +245,9 @@ struct ToolbarUpdatesPanel: View {
         imageFrames[id] = frame
     }
 
-    private func imageRank(_ group: Core.Image.LocalTagGroup) -> Int {
-        switch effectiveUpdateState(for: group) {
+    private func imageRank(_ group: Core.Image.LocalTagGroup,
+                           states: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState]) -> Int {
+        switch states[group.id] ?? .unknown {
         case .updateAvailable: return 0
         case .error: return 1
         case .checking, .unknown: return 2
@@ -194,12 +255,15 @@ struct ToolbarUpdatesPanel: View {
         }
     }
 
-    private func sortedImageGroups(_ groups: [Core.Image.LocalTagGroup]) -> [Core.Image.LocalTagGroup] {
+    private func sortedImageGroups(
+        _ groups: [Core.Image.LocalTagGroup],
+        states: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState]
+    ) -> [Core.Image.LocalTagGroup] {
         groups.sorted { lhs, rhs in
             switch ui.imageSort {
             case .status:
-                let lhsRank = imageRank(lhs)
-                let rhsRank = imageRank(rhs)
+                let lhsRank = imageRank(lhs, states: states)
+                let rhsRank = imageRank(rhs, states: states)
                 if lhsRank != rhsRank { return lhsRank < rhsRank }
             case .tags:
                 if lhs.references.count != rhs.references.count { return lhs.references.count > rhs.references.count }
@@ -210,14 +274,17 @@ struct ToolbarUpdatesPanel: View {
         }
     }
 
-    private func matchesFilter(_ group: Core.Image.LocalTagGroup) -> Bool {
+    private func matchesFilter(
+        _ group: Core.Image.LocalTagGroup,
+        states: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState]
+    ) -> Bool {
         switch ui.imageFilter {
         case .all:
             return true
         case .updates:
-            return effectiveUpdateState(for: group) == .updateAvailable
+            return states[group.id] == .updateAvailable
         case .errors:
-            return effectiveUpdateState(for: group) == .error
+            return states[group.id] == .error
         }
     }
 
@@ -226,8 +293,11 @@ struct ToolbarUpdatesPanel: View {
         return parsed.registry == "registry-1.docker.io" ? "docker.io" : parsed.registry
     }
 
-    private func statusTitle(_ group: Core.Image.LocalTagGroup) -> String {
-        switch effectiveUpdateState(for: group) {
+    private func statusTitle(
+        _ group: Core.Image.LocalTagGroup,
+        states: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState]
+    ) -> String {
+        switch states[group.id] ?? .unknown {
         case .updateAvailable: return "Updates available"
         case .error: return "Errors"
         case .checking, .unknown: return "Unknown"
@@ -244,10 +314,46 @@ struct ToolbarUpdatesPanel: View {
         }
     }
 
-    private func effectiveUpdateState(for group: Core.Image.LocalTagGroup) -> Core.Image.UpdateState {
-        let liveState = app.imageUpdateStatus(for: group.primaryReference).state
-        guard liveState == .checking else { return liveState }
-        return settledUpdateStates[group.id] ?? .unknown
+    private func makeProjection() -> Projection {
+        let allGroups = app.localImageGroups()
+        let liveStates = allGroups.reduce(into: [:]) { states, group in
+            states[group.id] = app.imageUpdateStatus(for: group).state
+        }
+        let effectiveStates = liveStates.mapValues { state in
+            state == .checking ? nil : state
+        }
+        .reduce(into: [Core.Image.LocalTagGroup.ID: Core.Image.UpdateState]()) { states, entry in
+            states[entry.key] = entry.value ?? settledUpdateStates[entry.key] ?? .unknown
+        }
+        let updateCount = effectiveStates.values.count(where: { $0 == .updateAvailable })
+        let activePage = page ?? .defaultPage(updateCount: updateCount)
+        let visibleGroups = allGroups.filter { group in
+            switch activePage {
+            case .updates:
+                return effectiveStates[group.id] == .updateAvailable
+            case .images:
+                return matchesFilter(group, states: effectiveStates)
+            }
+        }
+        let groups = sortedImageGroups(visibleGroups, states: effectiveStates)
+        let sections: [(title: String, groups: [Core.Image.LocalTagGroup])]
+        switch ui.imageGrouping {
+        case .none:
+            sections = [("", groups)]
+        case .registry:
+            sections = Dictionary(grouping: groups, by: registryTitle)
+                .map { ($0.key, sortedImageGroups($0.value, states: effectiveStates)) }
+                .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+        case .status:
+            sections = Dictionary(grouping: groups) { statusTitle($0, states: effectiveStates) }
+                .map { ($0.key, sortedImageGroups($0.value, states: effectiveStates)) }
+                .sorted { lhs, rhs in statusRank(lhs.title) < statusRank(rhs.title) }
+        }
+        return Projection(activePage: activePage,
+                          liveUpdateStates: liveStates,
+                          updateCount: updateCount,
+                          groups: groups,
+                          sections: sections)
     }
 
     private func rememberSettledUpdateStates(

--- a/Sources/ContainedApp/Persistence/AppDatabase/AppDatabase+RuntimeInventory.swift
+++ b/Sources/ContainedApp/Persistence/AppDatabase/AppDatabase+RuntimeInventory.swift
@@ -89,6 +89,9 @@ extension AppDatabase {
         var changed = consolidateDuplicateImageTags(&tagRecords)
         let imagesByIdentity = Dictionary(imageRecords.map { ($0.identity, $0) }, uniquingKeysWith: { first, _ in first })
         let tagsByID = Dictionary(tagRecords.map { ($0.scopedID, $0) }, uniquingKeysWith: { first, _ in first })
+        let groupIdentityByTagID = Dictionary(uniqueKeysWithValues: groups.flatMap { group in
+            group.tags.map { ($0.id, group.id) }
+        })
         var seenTags: Set<String> = []
         for group in groups {
             let identity = group.id
@@ -107,8 +110,9 @@ extension AppDatabase {
             }
         }
         for image in images {
-            let identity = image.digest ?? Core.Registry.ImageReference.normalizedKey(image.reference)
             let tagID = image.runtimeKind.scopedID(for: Core.Registry.ImageReference.normalizedKey(image.reference))
+            let identity = groupIdentityByTagID[tagID]
+                ?? Core.Registry.ImageReference.normalizedRepositoryKey(image.reference)
             guard seenTags.insert(tagID).inserted else { continue }
             let resourceData = encode(image)
             if let tag = tagsByID[tagID] {

--- a/Tests/ContainedAppTests/AppDatabaseTests.swift
+++ b/Tests/ContainedAppTests/AppDatabaseTests.swift
@@ -281,6 +281,22 @@ struct AppDatabaseTests {
         ])
     }
 
+    @Test func repositoryTagsWithDifferentDigestsShareImageMetadata() {
+        let database = AppDatabase(isStoredInMemoryOnly: true)
+        database.upsertImages([
+            image(reference: "ghcr.io/seerr-team/seerr:develop", id: "develop", digest: "sha256:develop", runtimeKind: .appleContainer),
+            image(reference: "ghcr.io/seerr-team/seerr:latest", id: "latest", digest: "sha256:latest", runtimeKind: .appleContainer),
+        ])
+
+        let image = database.fetch(ImageRecord.self).first
+        let tags = database.fetch(ImageTagRecord.self)
+        #expect(database.fetch(ImageRecord.self).count == 1)
+        #expect(image?.identity == "ghcr.io/seerr-team/seerr")
+        #expect(image?.digest == nil)
+        #expect(tags.count == 2)
+        #expect(tags.allSatisfy { $0.imageIdentity == image?.identity })
+    }
+
     @Test func imageUpdateStatusIsRuntimeScopedAtTagLevel() {
         let database = AppDatabase(isStoredInMemoryOnly: true)
         let app = AppModel(database: database)

--- a/Tests/ContainedAppTests/ContainerImageUpdateTests.swift
+++ b/Tests/ContainedAppTests/ContainerImageUpdateTests.swift
@@ -51,4 +51,41 @@ struct ContainerImageUpdateTests {
             .resolved(localDigest: "sha256:new", remoteDigest: "sha256:newer")
         #expect(app.containerImageUpdateState(for: snapshot) == .updateAvailable)
     }
+
+    @Test func repositoryGroupUsesUpdateStateFromEveryTag() throws {
+        let app = AppModel(database: AppDatabase(isStoredInMemoryOnly: true))
+        let images = try Core.Container.JSON.decode(
+            [Core.Image.Resource].self,
+            from: Data("""
+            [
+              {
+                "configuration": {
+                  "name": "ghcr.io/seerr-team/seerr:develop",
+                  "descriptor": { "digest": "sha256:develop" }
+                },
+                "id": "develop",
+                "variants": []
+              },
+              {
+                "configuration": {
+                  "name": "ghcr.io/seerr-team/seerr:latest",
+                  "descriptor": { "digest": "sha256:latest" }
+                },
+                "id": "latest",
+                "variants": []
+              }
+            ]
+            """.utf8),
+            runtimeKind: .appleContainer
+        )
+        app.setImages(images)
+        let group = try #require(app.localImageGroups().first)
+        app.imageUpdates[app.imageUpdateKey("ghcr.io/seerr-team/seerr:develop", runtimeKind: .appleContainer)] =
+            .resolved(localDigest: "sha256:develop", remoteDigest: "sha256:develop")
+        app.imageUpdates[app.imageUpdateKey("ghcr.io/seerr-team/seerr:latest", runtimeKind: .appleContainer)] =
+            .resolved(localDigest: "sha256:latest", remoteDigest: "sha256:new")
+
+        #expect(app.imageUpdateStatus(for: group).state == .updateAvailable)
+        #expect(app.firstImageTagWithUpdate(in: group)?.reference == "ghcr.io/seerr-team/seerr:latest")
+    }
 }

--- a/Tests/ContainedAppTests/ToolbarUpdatesPanelTests.swift
+++ b/Tests/ContainedAppTests/ToolbarUpdatesPanelTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import ContainedApp
+
+@Suite("Images panel pages")
+struct ToolbarUpdatesPanelTests {
+    @Test func defaultsToUpdatesOnlyWhenUpdatesAreAvailable() {
+        #expect(ToolbarUpdatesPanel.ImagePage.defaultPage(updateCount: 1) == .updates)
+        #expect(ToolbarUpdatesPanel.ImagePage.defaultPage(updateCount: 0) == .images)
+    }
+}


### PR DESCRIPTION
## Summary

- group local image tags by normalized registry/repository identity, even when tags have different digests
- retain digest-based grouping for aliases across repositories and keep per-tag runtime availability
- persist every runtime tag against the shared repository group
- split image management into Updates and Images pages with update-aware defaults and page-specific controls
- compute one active Images-page projection per render and refresh only the selected System page
- aggregate repository update state across every tag so non-primary tag updates remain actionable

## Verification

- `swift test --package-path Packages/ContainedCore --filter ImageWorkflowTests`
- `swift test --filter repositoryTagsWithDifferentDigestsShareImageMetadata`
- `swift test` (133 tests)
- `xcodebuild -workspace Contained.xcworkspace -scheme Contained -configuration Debug build`
- `xcodebuild -workspace Contained.xcworkspace -scheme Contained -configuration Debug test` (116 tests)
- `./Scripts/check.sh repo`
- `git diff --check`
- `./Scripts/package.sh app debug`
