### PR TITLE
Verify image recreation outcomes

### DIFF
--- a/Changes/Current.md
+++ b/Changes/Current.md
@@ -1,0 +1,1 @@
+- Verify image-update recreations use the freshly pulled image and survive startup, and surface streamed pull failures instead of reporting false success.

--- a/Documentation/Features/Containers.md
+++ b/Documentation/Features/Containers.md
@@ -42,7 +42,8 @@ that the container's immutable image identity differs from the current tag—or 
 newer registry digest is available—the action is relabeled **Update Container**
 and an orange update button appears persistently at the far right of the card
 footer. Updating pulls first only
-when needed, then recreates through the same rollback path as Edit → Save.
+when needed, then recreates through the same rollback path as Edit → Save. A
+failed streamed pull stops the update instead of being reported as successful.
 Rebuild and Update preserve whether the container was running or stopped, while
 ordinary Start, Stop, and Restart remain non-destructive lifecycle operations.
 
@@ -108,7 +109,14 @@ containers in the [Creation Workflow](/Documentation/Features/Creation-Workflow.
 
 Runtime configuration is immutable, so saving an edit recreates the container.
 Contained validates the replacement and a snapshot-derived rollback recipe before
-deleting anything. If replacement creation then fails, Core automatically tries
-to restore the original container. A failed restoration keeps the original recipe
-in the app database for recovery; data that was not stored in volumes cannot be
-reconstructed.
+deleting anything, and records the locally resolved image identity. After creating
+the replacement, Contained verifies that it uses that identity and, when the
+original was running, remains running after initial startup. A failed creation or
+verification removes any replacement and makes Core try to restore the original
+container.
+
+Rollback restores the original definition and running state from its image
+reference. If a mutable tag has moved and the runtime no longer retains the prior
+image data, rollback cannot guarantee restoration of the exact earlier image
+digest. A failed restoration keeps the original recipe in the app database for
+recovery; data that was not stored in volumes cannot be reconstructed.

--- a/Packages/ContainedCore/Sources/ContainedCore/Command/Runner.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Command/Runner.swift
@@ -149,35 +149,44 @@ final class Runner: Running {
             process.standardError = pipe
             let handle = pipe.fileHandleForReading
 
-            handle.readabilityHandler = { handle in
-                let data = handle.availableData
-                guard !data.isEmpty else { return }
-                continuation.yield(String(decoding: data, as: UTF8.self))
-            }
-
-            process.terminationHandler = { _ in
-                handle.readabilityHandler = nil
-                continuation.finish()
-            }
-
             continuation.onTermination = { _ in
-                box.handle?.readabilityHandler = nil
                 if box.process.isRunning { box.process.terminate() }
             }
 
-            box.handle = handle
             DispatchQueue.global(qos: priority.dispatchQoS).async {
                 do {
                     try process.run()
                 } catch {
                     continuation.finish(throwing: Core.Command.Error.launchFailed(underlying: error.localizedDescription))
+                    return
                 }
+
+                var output = Data()
+                while true {
+                    let data = handle.availableData
+                    guard !data.isEmpty else { break }
+                    output.append(data)
+                    continuation.yield(String(decoding: data, as: UTF8.self))
+                }
+                process.waitUntilExit()
+
+                guard process.terminationStatus != 0 else {
+                    continuation.finish()
+                    return
+                }
+                let detail = String(decoding: output, as: UTF8.self)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                continuation.finish(throwing: Core.Command.Error.nonZeroExit(
+                    code: process.terminationStatus,
+                    stderr: detail,
+                    command: arguments.joined(separator: " ")
+                ))
             }
         }
     }
 }
 
-/// A Sendable holder for the non-Sendable `Process`/`FileHandle` used by `stream`'s teardown.
+/// A Sendable holder for the non-Sendable `Process` used by `stream`'s teardown.
 ///
 /// `@unchecked Sendable` is sound here by construction, not by the compiler's reasoning: the box is
 /// only ever touched from the stream's single `onTermination`/`terminationHandler` callbacks, which
@@ -186,7 +195,6 @@ final class Runner: Running {
 /// the access pattern (one writer at setup, one reader at teardown) carries no data race.
 private final class ProcessBox: @unchecked Sendable {
     let process = Process()
-    var handle: FileHandle?
 }
 
 private final class DataBox: @unchecked Sendable {
@@ -200,6 +208,7 @@ private final class DataBox: @unchecked Sendable {
     func set(_ data: Data) {
         lock.withLock { storage = data }
     }
+
 }
 
 }

--- a/Packages/ContainedCore/Sources/ContainedCore/Runtime/ClientDefaults.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Runtime/ClientDefaults.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 extension RuntimeContainerClient {
+    var recreateVerificationDelay: Duration { .zero }
+
     func prepareCreateRequest(_ request: Core.Container.CreateRequest) async throws -> Core.Container.CreateRequest {
         request
     }
@@ -40,6 +42,8 @@ extension RuntimeContainerClient {
         // lookups to turn inspected implementation details back into stable create arguments.
         let replacement = try await prepareCreateRequest(replacement)
         let rollback = try await prepareCreateRequest(rollback)
+        let originalWasRunning = try? await containerSnapshot(matching: originalID)?.state == .running
+        let expectedImageIdentities = try await resolvedImageIdentities(for: replacement.image)
         _ = try? await stop([originalID])
         let deletedOriginal: Bool
         do {
@@ -50,10 +54,19 @@ extension RuntimeContainerClient {
                                                  primaryError: error)
         }
 
+        var createdReplacementID: String?
         do {
-            return try await createContainer(replacement)
+            let result = try await createContainer(replacement)
+            createdReplacementID = result.id ?? replacement.name
+            try await verifyReplacement(id: createdReplacementID,
+                                        expectedImageIdentities: expectedImageIdentities,
+                                        mustBeRunning: originalWasRunning == true)
+            return result
         } catch {
             let replacementError = error
+            if let createdReplacementID, !createdReplacementID.isEmpty {
+                _ = try? await deleteContainerIfPresent(createdReplacementID, force: true)
+            }
             guard deletedOriginal else {
                 throw Core.Container.RecreateFailure(phase: .createReplacement,
                                                      recovery: .notNeeded,
@@ -73,6 +86,52 @@ extension RuntimeContainerClient {
         }
     }
 
+    private func resolvedImageIdentities(for reference: String) async throws -> Set<String>? {
+        guard let imageClient = self as? any RuntimeImageClient else { return nil }
+        let images = try await imageClient.inspectImage(reference)
+        let identities = images.reduce(into: Set<String>()) { result, image in
+            result.insert(Self.normalizedImageIdentity(image.id))
+            if let digest = image.digest {
+                result.insert(Self.normalizedImageIdentity(digest))
+            }
+        }
+        return identities.isEmpty ? nil : identities
+    }
+
+    private func verifyReplacement(id: String?,
+                                   expectedImageIdentities: Set<String>?,
+                                   mustBeRunning: Bool) async throws {
+        guard let id, !id.isEmpty else {
+            throw RecreateVerificationError.replacementUnavailable(id: "")
+        }
+        try await Task.sleep(for: recreateVerificationDelay)
+        guard let replacement = try await containerSnapshot(matching: id) else {
+            throw RecreateVerificationError.replacementUnavailable(id: id)
+        }
+        if let expectedImageIdentities {
+            guard let digest = replacement.configuration.image.descriptor?.digest,
+                  expectedImageIdentities.contains(Self.normalizedImageIdentity(digest)) else {
+                throw RecreateVerificationError.imageMismatch(
+                    expected: expectedImageIdentities.sorted(),
+                    actual: replacement.configuration.image.descriptor?.digest
+                )
+            }
+        }
+        if mustBeRunning, replacement.state != .running {
+            throw RecreateVerificationError.replacementNotRunning(id: id, state: replacement.rawState)
+        }
+    }
+
+    private func containerSnapshot(matching id: String) async throws -> Core.Container.Snapshot? {
+        try await listContainers(all: true).first {
+            $0.id == id || $0.scopedID == id || $0.scopedID == descriptor.kind.scopedID(for: id)
+        }
+    }
+
+    private static func normalizedImageIdentity(_ identity: String) -> String {
+        identity.hasPrefix("sha256:") ? String(identity.dropFirst("sha256:".count)) : identity
+    }
+
     private func deleteContainerIfPresent(_ id: String, force: Bool) async throws -> Bool {
         if let current = try? await listContainers(all: true),
            !current.contains(where: { $0.id == id || $0.scopedID == id || $0.scopedID == descriptor.kind.scopedID(for: id) }) {
@@ -83,6 +142,35 @@ extension RuntimeContainerClient {
             return true
         } catch let error as Core.Command.Error where error.isContainerNotFound {
             return false
+        }
+    }
+}
+
+private enum RecreateVerificationError: LocalizedError, Core.Error.PackageError {
+    case replacementUnavailable(id: String)
+    case replacementNotRunning(id: String, state: String)
+    case imageMismatch(expected: [String], actual: String?)
+
+    var packageName: String { "ContainedCore" }
+
+    var packageErrorCode: String {
+        switch self {
+        case .replacementUnavailable: "recreateReplacementUnavailable"
+        case .replacementNotRunning: "recreateReplacementNotRunning"
+        case .imageMismatch: "recreateImageMismatch"
+        }
+    }
+
+    var packageErrorContext: [String: String] { [:] }
+
+    var errorDescription: String? {
+        switch self {
+        case .replacementUnavailable(let id):
+            "Replacement container \(id) was not available after creation."
+        case .replacementNotRunning(let id, let state):
+            "Replacement container \(id) entered state \(state) during startup verification."
+        case .imageMismatch(let expected, let actual):
+            "Replacement resolved image \(actual ?? "unknown") instead of \(expected.joined(separator: ", "))."
         }
     }
 }

--- a/Packages/ContainedCore/Sources/ContainedCore/Runtime/ClientProtocols.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Runtime/ClientProtocols.swift
@@ -5,6 +5,7 @@ protocol RuntimeDescribing: Sendable {
 }
 
 protocol RuntimeContainerClient: RuntimeDescribing {
+    var recreateVerificationDelay: Duration { get }
     func listContainers(all: Bool) async throws -> [Core.Container.Snapshot]
     func stats(ids: [String]) async throws -> [Core.Metrics.ContainerStats]
     func streamStats(ids: [String]) -> AsyncThrowingStream<[Core.Metrics.RuntimeStatsSnapshot], Error>

--- a/Packages/ContainedCore/Sources/ContainedCore/Runtimes/AppleContainer/Client/Client.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Runtimes/AppleContainer/Client/Client.swift
@@ -5,6 +5,7 @@ import Foundation
 struct AppleContainerClient: Sendable {
     let runner: any Core.Command.Running
     var descriptor: Core.Runtime.Descriptor { .appleContainer }
+    var recreateVerificationDelay: Duration { .seconds(1) }
 
     init(runner: any Core.Command.Running) {
         self.runner = runner

--- a/Packages/ContainedCore/Sources/ContainedCore/Runtimes/Docker/Client/DockerClient.swift
+++ b/Packages/ContainedCore/Sources/ContainedCore/Runtimes/Docker/Client/DockerClient.swift
@@ -3,6 +3,7 @@ import Foundation
 struct DockerClient: Sendable {
     let runner: any Core.Command.Running
     var descriptor: Core.Runtime.Descriptor { .docker }
+    var recreateVerificationDelay: Duration { .seconds(1) }
 
     init(runner: any Core.Command.Running) {
         self.runner = runner

--- a/Packages/ContainedCore/Tests/ContainedCoreTests/CommandTests.swift
+++ b/Packages/ContainedCore/Tests/ContainedCoreTests/CommandTests.swift
@@ -129,6 +129,30 @@ struct CommandTests {
         }
     }
 
+    @Test func streamedCommandPropagatesNonZeroExit() async {
+        let runner = Core.Command.Runner(executableURL: URL(fileURLWithPath: "/bin/sh"))
+        var streamed = ""
+
+        do {
+            for try await chunk in runner.stream(["-c", "printf 'pull failed'; exit 7"]) {
+                streamed += chunk
+            }
+            Issue.record("Expected the streamed command to fail")
+        } catch let error as Core.Command.Error {
+            guard case .nonZeroExit(let code, let stderr, let command) = error else {
+                Issue.record("Expected a non-zero exit error")
+                return
+            }
+            #expect(code == 7)
+            #expect(stderr.contains("pull failed"))
+            #expect(command == "-c printf 'pull failed'; exit 7")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(streamed.contains("pull failed"))
+    }
+
     @Test func statsDeltaComputesCPUFraction() {
         let prev = Core.Metrics.ContainerStats(id: "x", cpuUsageUsec: 1_000_000, memoryUsageBytes: 100, memoryLimitBytes: 1000,
                                   blockReadBytes: 0, blockWriteBytes: 0, networkRxBytes: 0, networkTxBytes: 0, numProcesses: 1)

--- a/Packages/ContainedCore/Tests/ContainedCoreTests/Runtime/RuntimeDescriptorTests.swift
+++ b/Packages/ContainedCore/Tests/ContainedCoreTests/Runtime/RuntimeDescriptorTests.swift
@@ -323,6 +323,95 @@ struct RuntimeDescriptorTests {
         }
     }
 
+    @Test func recreateRejectsStaleReplacementImageAndRestoresOriginal() async throws {
+        let expected = Core.Image.Resource(
+            configuration: Core.Image.Configuration(
+                name: "nginx:latest",
+                descriptor: Core.Container.Descriptor(digest: "sha256:new", mediaType: nil, size: nil),
+                creationDate: nil
+            ),
+            id: "new",
+            runtimeKind: .appleContainer
+        )
+        let runtime = RecordingContainerRuntime(
+            containers: [.placeholder(id: "web", image: "nginx:latest", runtimeKind: .appleContainer)],
+            inspectedImages: [expected],
+            creationDigests: ["sha256:old", "sha256:new"]
+        )
+        let orchestrator = Core.Orchestrator(
+            cliURLs: [.appleContainer: URL(fileURLWithPath: "/usr/bin/container")],
+            runtimes: [.appleContainer: runtime] as [Core.Runtime.Kind: any RuntimeClient]
+        )
+
+        do {
+            _ = try await orchestrator.recreateContainer(originalID: "web",
+                                                         replacement: recreateDocument(),
+                                                         rollback: recreateDocument(name: "web"))
+            Issue.record("Expected stale replacement verification to fail")
+        } catch let error as Core.Container.RecreateFailure {
+            #expect(error.phase == .createReplacement)
+            #expect(error.recovery == .originalRestored)
+            #expect(error.primaryFailure.code == "recreateImageMismatch")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(await runtime.deletedIDs == ["web", "created"])
+        #expect(await runtime.createdRequests.map(\.name) == ["created", "web"])
+    }
+
+    @Test func recreateKeepsOriginalWhenImageInspectionFails() async throws {
+        let inspectionError = Core.Command.Error.nonZeroExit(code: 1,
+                                                              stderr: "image service unavailable",
+                                                              command: "image inspect nginx:latest")
+        let runtime = RecordingContainerRuntime(
+            containers: [.placeholder(id: "web", image: "nginx:latest", runtimeKind: .appleContainer)],
+            inspectError: inspectionError
+        )
+        let orchestrator = Core.Orchestrator(
+            cliURLs: [.appleContainer: URL(fileURLWithPath: "/usr/bin/container")],
+            runtimes: [.appleContainer: runtime] as [Core.Runtime.Kind: any RuntimeClient]
+        )
+
+        do {
+            _ = try await orchestrator.recreateContainer(originalID: "web",
+                                                         replacement: recreateDocument(),
+                                                         rollback: recreateDocument(name: "web"))
+            Issue.record("Expected image inspection to fail")
+        } catch let error as Core.Command.Error {
+            #expect(error == inspectionError)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(await runtime.deletedIDs.isEmpty)
+        #expect(await runtime.createdRequests.isEmpty)
+    }
+
+    @Test func recreateRejectsReplacementThatStopsDuringStartup() async throws {
+        let runtime = RecordingContainerRuntime(
+            containers: [.placeholder(id: "web", image: "nginx:latest", runtimeKind: .appleContainer)],
+            creationStates: [.stopped, .running]
+        )
+        let orchestrator = Core.Orchestrator(
+            cliURLs: [.appleContainer: URL(fileURLWithPath: "/usr/bin/container")],
+            runtimes: [.appleContainer: runtime] as [Core.Runtime.Kind: any RuntimeClient]
+        )
+
+        do {
+            _ = try await orchestrator.recreateContainer(originalID: "web",
+                                                         replacement: recreateDocument(),
+                                                         rollback: recreateDocument(name: "web"))
+            Issue.record("Expected stopped replacement verification to fail")
+        } catch let error as Core.Container.RecreateFailure {
+            #expect(error.phase == .createReplacement)
+            #expect(error.recovery == .originalRestored)
+            #expect(error.primaryFailure.code == "recreateReplacementNotRunning")
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
     private func recreateDocument(name: String = "created", image: String = "nginx:latest") -> Core.Schema.Document {
         var request = Core.Container.CreateRequest(runtimeKind: .appleContainer)
         request.image = image
@@ -414,7 +503,7 @@ private enum TestStubError: Error {
     case unused
 }
 
-private actor RecordingContainerRuntime: RuntimeClient, RuntimeContainerClient {
+private actor RecordingContainerRuntime: RuntimeClient, RuntimeContainerClient, RuntimeImageClient {
     nonisolated let descriptor = Core.Runtime.Descriptor.appleContainer
     var containers: [Core.Container.Snapshot]
     var deleteError: Core.Command.Error?
@@ -422,13 +511,25 @@ private actor RecordingContainerRuntime: RuntimeClient, RuntimeContainerClient {
     var deletedIDs: [String] = []
     var stoppedIDs: [String] = []
     var createdRequests: [Core.Container.CreateRequest] = []
+    var inspectedImages: [Core.Image.Resource]
+    var inspectError: Core.Command.Error?
+    var creationDigests: [String?]
+    var creationStates: [Core.Runtime.Status]
 
     init(containers: [Core.Container.Snapshot],
          deleteError: Core.Command.Error? = nil,
-         createErrors: [Core.Command.Error] = []) {
+         createErrors: [Core.Command.Error] = [],
+         inspectedImages: [Core.Image.Resource] = [],
+         inspectError: Core.Command.Error? = nil,
+         creationDigests: [String?] = [],
+         creationStates: [Core.Runtime.Status] = []) {
         self.containers = containers
         self.deleteError = deleteError
         self.createErrors = createErrors
+        self.inspectedImages = inspectedImages
+        self.inspectError = inspectError
+        self.creationDigests = creationDigests
+        self.creationStates = creationStates
     }
 
     func listContainers(all: Bool) async throws -> [Core.Container.Snapshot] { containers }
@@ -445,7 +546,26 @@ private actor RecordingContainerRuntime: RuntimeClient, RuntimeContainerClient {
     func createContainer(_ request: Core.Container.CreateRequest) async throws -> Core.Container.CreateResult {
         createdRequests.append(request)
         if !createErrors.isEmpty { throw createErrors.removeFirst() }
-        return Core.Container.CreateResult(id: "created")
+        let id = request.name.isEmpty ? "created" : request.name
+        let digest = creationDigests.isEmpty ? nil : creationDigests.removeFirst()
+        let state = creationStates.isEmpty ? Core.Runtime.Status.running : creationStates.removeFirst()
+        let descriptor = digest.map { Core.Container.Descriptor(digest: $0, mediaType: nil, size: nil) }
+        let initProcess = try JSONDecoder().decode(Core.Container.ProcessConfiguration.self,
+                                                   from: Data("{}".utf8))
+        let configuration = Core.Container.Configuration(
+            runtimeKind: .appleContainer,
+            id: id,
+            image: Core.Container.ImageReference(reference: request.image, descriptor: descriptor),
+            initProcess: initProcess
+        )
+        containers.removeAll { $0.id == id }
+        containers.append(Core.Container.Snapshot(
+            configuration: configuration,
+            id: id,
+            status: Core.Container.RuntimeState(state: state),
+            runtimeKind: .appleContainer
+        ))
+        return Core.Container.CreateResult(id: id)
     }
     func runContainer(arguments: [String]) async throws -> Data { Data() }
     func start(_ ids: [String]) async throws -> Data { Data() }
@@ -456,7 +576,30 @@ private actor RecordingContainerRuntime: RuntimeClient, RuntimeContainerClient {
     func deleteContainers(_ ids: [String], force: Bool) async throws -> Data {
         deletedIDs.append(contentsOf: ids)
         if let deleteError { throw deleteError }
+        containers.removeAll { ids.contains($0.id) }
         return Data()
     }
     func pruneContainers() async throws -> Data { Data() }
+    func images() async throws -> [Core.Image.Resource] { inspectedImages }
+    func inspectImage(_ ref: String) async throws -> [Core.Image.Resource] {
+        if let inspectError { throw inspectError }
+        return inspectedImages
+    }
+    nonisolated func streamPull(_ ref: String, platform: String?) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    nonisolated func streamBuild(context: String, tag: String?, dockerfile: String?,
+                                 buildArgs: [String: String], noCache: Bool,
+                                 platform: String?) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    nonisolated func streamPush(_ ref: String, platform: String?) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { $0.finish() }
+    }
+    func deleteImages(_ refs: [String]) async throws -> Data { Data() }
+    func tagImage(source: String, target: String) async throws -> Data { Data() }
+    func saveImages(_ refs: [String], to output: String) async throws -> Data { Data() }
+    func loadImages(from input: String) async throws -> Data { Data() }
+    func exportContainer(_ id: String, to output: String) async throws -> Data { Data() }
+    func pruneImages(all: Bool) async throws -> Data { Data() }
 }


### PR DESCRIPTION
## Summary

- propagate non-zero exits from streamed runtime commands so a failed pull cannot report success
- resolve the replacement tag before teardown and verify the created container uses that image identity
- give detached replacements a short startup grace period and restore the original definition when a previously running replacement exits immediately
- abort before deleting the original when the runtime image service cannot inspect the replacement image

## Investigation

Contained passed the mutable tag through to Apple Container correctly; it did not pin the recreate request to the stale digest. Two false-success paths were in Contained:

1. The streaming command runner finished normally for every process termination, including non-zero pull exits.
2. A detached run was considered successful as soon as the CLI returned, without checking the resulting container descriptor or whether a previously running service survived startup.

The incident-time Apple Container logs also show repeated container-core-images XPC invalidations and service restarts. That is consistent with the runtime returning or retaining stale image state, but does not prove an upstream root cause. The new preflight and post-create checks make that runtime failure visible and recoverable instead of reporting a successful update.

Rollback restores the saved definition through its image reference. If a mutable tag moved and the runtime discarded the earlier image data, it cannot guarantee restoration of the exact previous digest; this limitation is now documented.

## Verification

- swift test (root): 138 tests passed
- swift test (Packages/ContainedCore): 112 tests passed
- swift build
- ./Scripts/check.sh repo
- git diff --check

Fixes #74
